### PR TITLE
Make JoinableOutputStream count input stream refs and close when they…

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/callback/StreamCallbacks.java
+++ b/src/main/java/org/commonjava/util/partyline/callback/StreamCallbacks.java
@@ -31,6 +31,8 @@ public interface StreamCallbacks
 
     void flushed();
 
+    void beforeClose();
+
     void closed();
 
 }

--- a/src/test/java/org/commonjava/util/partyline/JoinableOutputStreamTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableOutputStreamTest.java
@@ -139,7 +139,7 @@ public class JoinableOutputStreamTest
     {
         final CountDownLatch latch = new CountDownLatch( 2 );
         final JoinableOutputStream stream = startTimedWrite( 1, latch );
-        startRead( 18000, stream, latch );
+        startRead( 1000, stream, latch );
         //        startRead( 500, stream, latch );
 
         System.out.println( "Waiting for " + name.getMethodName() + " threads to complete." );
@@ -160,6 +160,7 @@ public class JoinableOutputStreamTest
     }
 
     @Test
+    @Ignore( "Using reference counts to close JoinableOutputStream when last input closes." )
     public void outputStreamWaitsForSingleJoinedInputStreamToClose()
         throws Exception
     {
@@ -179,6 +180,7 @@ public class JoinableOutputStreamTest
     }
 
     @Test
+    @Ignore( "Using reference counts to close JoinableOutputStream when last input closes." )
     public void outputStreamWaitsForTwoJoinedInputStreamsToClose()
         throws Exception
     {

--- a/src/test/java/org/commonjava/util/partyline/fixture/AbstractJointedIOTest.java
+++ b/src/test/java/org/commonjava/util/partyline/fixture/AbstractJointedIOTest.java
@@ -36,6 +36,7 @@
 package org.commonjava.util.partyline.fixture;
 
 import java.io.File;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -71,6 +72,15 @@ public abstract class AbstractJointedIOTest
         final Thread t = new Thread( runnable );
         t.setName( name.getMethodName() + "::" + named );
         t.setDaemon( true );
+        t.setUncaughtExceptionHandler( new UncaughtExceptionHandler()
+        {
+            @Override
+            public void uncaughtException( final Thread t, final Throwable e )
+            {
+                e.printStackTrace();
+                Assert.fail( t.getName() + ": " + e.getMessage() );
+            }
+        } );
         return t;
     }
 


### PR DESCRIPTION
…'re all done, without blocking the OutputStream.close() method. Add stream callbacks directly to the JoinableOutputStream, and add a beforeClose() method to allow the JoinableOutputStream to deregister itself from the JoinableFileManager (without unlocking the file it's managing until closed() is called in the callbacks instance).
