### PR TITLE
Effectively eliminate read locking.

### DIFF
--- a/src/test/java/org/commonjava/util/partyline/AsyncFileReader.java
+++ b/src/test/java/org/commonjava/util/partyline/AsyncFileReader.java
@@ -32,7 +32,7 @@ public final class AsyncFileReader
     implements Runnable
 {
 
-    private final JoinableOutputStream stream;
+    private final JoinableFile stream;
 
     private final CountDownLatch latch;
 
@@ -45,7 +45,7 @@ public final class AsyncFileReader
     private final long readDelay;
 
     public AsyncFileReader( final long initialDelay, final long readDelay, final long closeDelay,
-                            final JoinableOutputStream stream,
+                            final JoinableFile stream,
                             final CountDownLatch latch )
     {
         this.initialDelay = initialDelay;

--- a/src/test/java/org/commonjava/util/partyline/fixture/AbstractJointedIOTest.java
+++ b/src/test/java/org/commonjava/util/partyline/fixture/AbstractJointedIOTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import org.commonjava.util.partyline.AsyncFileReader;
-import org.commonjava.util.partyline.JoinableOutputStream;
+import org.commonjava.util.partyline.JoinableFile;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -114,13 +114,13 @@ public abstract class AbstractJointedIOTest
         return timings;
     }
 
-    protected void startRead( final long initialDelay, final JoinableOutputStream stream, final CountDownLatch latch )
+    protected void startRead( final long initialDelay, final JoinableFile stream, final CountDownLatch latch )
     {
         startRead( initialDelay, -1, -1, stream, latch );
     }
 
     protected void startRead( final long initialDelay, final long readDelay, final long closeDelay,
-                              final JoinableOutputStream stream, final CountDownLatch latch )
+                              final JoinableFile stream, final CountDownLatch latch )
     {
         newThread( "reader" + readers++, new AsyncFileReader( initialDelay, readDelay, closeDelay, stream, latch ) ).start();
     }
@@ -131,21 +131,21 @@ public abstract class AbstractJointedIOTest
         newThread( "reader" + readers++, new AsyncFileReader( initialDelay, readDelay, closeDelay, file, latch ) ).start();
     }
 
-    protected JoinableOutputStream startTimedWrite( final long delay, final CountDownLatch latch )
+    protected JoinableFile startTimedWrite( final long delay, final CountDownLatch latch )
         throws Exception
     {
         final File file = temp.newFile();
         return startTimedWrite( file, delay, latch );
     }
 
-    protected JoinableOutputStream startTimedWrite( final File file, final long delay, final CountDownLatch latch )
+    protected JoinableFile startTimedWrite( final File file, final long delay, final CountDownLatch latch )
         throws Exception
     {
-        final JoinableOutputStream stream = new JoinableOutputStream( file );
+        final JoinableFile jf = new JoinableFile( file, true );
 
-        newThread( "writer" + writers++, new TimedFileWriter( stream, delay, latch ) ).start();
+        newThread( "writer" + writers++, new TimedFileWriter( jf, delay, latch ) ).start();
 
-        return stream;
+        return jf;
     }
 
 }

--- a/src/test/java/org/commonjava/util/partyline/fixture/TimedFileWriter.java
+++ b/src/test/java/org/commonjava/util/partyline/fixture/TimedFileWriter.java
@@ -18,18 +18,18 @@ package org.commonjava.util.partyline.fixture;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.commons.io.IOUtils;
-import org.commonjava.util.partyline.JoinableOutputStream;
+import org.commonjava.util.partyline.JoinableFile;
 
 public final class TimedFileWriter
     implements Runnable
 {
     private final long delay;
 
-    private final JoinableOutputStream stream;
+    private final JoinableFile stream;
 
     private final CountDownLatch latch;
 
-    public TimedFileWriter( final JoinableOutputStream stream, final long delay, final CountDownLatch latch )
+    public TimedFileWriter( final JoinableFile stream, final long delay, final CountDownLatch latch )
     {
         this.stream = stream;
         this.delay = delay;
@@ -51,7 +51,7 @@ public final class TimedFileWriter
                 Thread.sleep( delay );
 
                 //                    System.out.println( "Writing: " + i );
-                stream.write( String.format( "%d\n", i )
+                stream.getOutputStream().write( String.format( "%d\n", i )
                                     .getBytes() );
             }
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.commonjava.util.partyline" level="TRACE" />
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>


### PR DESCRIPTION
- refactor JoinableOutputStream to JoinableFile, with embedded JoinableOutputStream
- allow JoinableFile that is not writable, for instances opened by openInputStream()
- use JoinableFile from openInputStream() to allow concurrent reads when there is no writer.
