### PR TITLE
Fix closing input stream breaks output stream (test case)

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -263,26 +263,23 @@ public class JoinableFile
     }
 
     /**
-     * Callback for use in {@link JoinInputStream} to notify this stream to decrement its count of associated input streams. Then, call 
-     * {@link #notifyAll()} just in case {@link #close()} is executing, so it can re-check the jointCount and see if it's time to close down
-     * the backing storage.
+     * Callback for use in {@link JoinInputStream} to notify this stream to decrement its count of associated input streams.
      * @throws IOException 
      */
     private synchronized void jointClosed()
         throws IOException
     {
         jointCount--;
-        notifyAll();
 
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "jointClosed() called in: {}, current joint count: {}", this, jointCount );
         if ( jointCount <= 0 )
         {
-            if ( output == null )
+            if ( output == null || output.closed )
             {
                 closed = true;
+                reallyClose();
             }
-            reallyClose();
         }
     }
 

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
@@ -244,6 +244,30 @@ public class JoinableFileTest
     }
 
     @Test
+    public void joinFileWriteContinueAfterInputStreamClose()
+            throws Exception
+    {
+        final CountDownLatch latch = new CountDownLatch( 1 );
+        final JoinableFile stream = startTimedWrite( 1, latch );
+
+        InputStream inStream = stream.joinStream();
+        InputStream inStream2 = stream.joinStream();
+        Thread.sleep(1000);
+        inStream.close();
+        inStream2.close();
+        System.out.println( "All input stream closed. Waiting for " + name.getMethodName() + " writer thread to complete." );
+        latch.await();
+
+        final File file = new File( stream.getPath() );
+        System.out.println( "File length: " + file.length() );
+
+        final List<String> lines = FileUtils.readLines( file );
+        System.out.println( lines );
+
+        assertThat( lines.size(), equalTo( COUNT ) );
+    }
+
+    @Test
     public void joinFileWriteJustBeforeFinished()
         throws Exception
     {


### PR DESCRIPTION
The committed test case shows us that if all input streams are closed, the reallyClose() will be executed regardless whether there is anyone still writing to the join-able stream. That will break the writer. If this is a valid use case, I will make a fix for it. 
