### PR TITLE
A concurrent test for the dead lock problem with some fix

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -239,6 +239,10 @@ public class JoinableFile
             logger.trace( "Joints closed, really closing..." );
             reallyClose();
         }
+        else
+        {
+            owner.unlock();
+        }
     }
 
     /**
@@ -325,6 +329,10 @@ public class JoinableFile
                 closed = true;
                 reallyClose();
             }
+        }
+        else
+        {
+            owner.unlock();
         }
     }
 


### PR DESCRIPTION
@jdcasey I've added a concurrent test with all 3 ops in parallel, and found that it will have a dead lock. Seems the problem is that when the joinable read stream is closing, if there at least 2 read stream there, the lockowner will not correctly release the lock. This also happens for the write stream. 

I've added the the lock releasing code in JF class, need your review for correctness.

But seems that there is still one problem. When the concurrent ops happens, if the delete ops happens at first and correctly delete the file, the subsequent ops like joint reading will be blocked again. Need further checking of this case.(Is this case reasonable?)