### PR TITLE
embed joinStream()/getOutputStream() call in FileTree.joinOrSetFile()…

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
+++ b/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
@@ -1,0 +1,54 @@
+package org.commonjava.util.partyline;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Locks a single operation on a File in this FileTree, so competing operations ON THAT FILE have to wait, but
+ * operations on other files can continue.
+ */
+final class FileOperationLock
+{
+    private ReentrantLock lock = new ReentrantLock();
+
+    private Condition changed = lock.newCondition();
+
+    public void lock()
+    {
+        lock.lock();
+    }
+
+    public void unlock()
+    {
+        lock.unlock();
+    }
+
+    public void await( long timeoutMs )
+            throws InterruptedException
+    {
+        changed.await( timeoutMs, TimeUnit.MILLISECONDS );
+    }
+
+    public void signal()
+    {
+        changed.signal();
+    }
+
+    public <T> T lockAnd( LockedFileOperation<T> op )
+            throws IOException, InterruptedException
+    {
+        try
+        {
+            lock();
+
+            return op.execute( this );
+        }
+        finally
+        {
+            unlock();
+        }
+    }
+
+}

--- a/src/main/java/org/commonjava/util/partyline/LockedFileOperation.java
+++ b/src/main/java/org/commonjava/util/partyline/LockedFileOperation.java
@@ -1,0 +1,13 @@
+package org.commonjava.util.partyline;
+
+import java.io.IOException;
+
+/**
+ * Created by jdcasey on 12/8/16.
+ */
+@FunctionalInterface
+interface LockedFileOperation<T>
+{
+    T execute( FileOperationLock opLock )
+            throws InterruptedException, IOException;
+}

--- a/src/test/java/org/commonjava/util/partyline/AbstractBytemanTest.java
+++ b/src/test/java/org/commonjava/util/partyline/AbstractBytemanTest.java
@@ -1,0 +1,26 @@
+package org.commonjava.util.partyline;
+
+import org.apache.commons.io.IOUtils;
+import org.jboss.byteman.synchronization.CountDown;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.commonjava.util.partyline.fixture.ThreadDumper.timeoutRule;
+
+/**
+ * Created by jdcasey on 12/8/16.
+ */
+public class AbstractBytemanTest
+        extends AbstractJointedIOTest
+{
+
+    @ClassRule
+    public static TestRule timeout = timeoutRule( 30, TimeUnit.SECONDS );
+
+}

--- a/src/test/java/org/commonjava/util/partyline/AbstractJointedIOTest.java
+++ b/src/test/java/org/commonjava/util/partyline/AbstractJointedIOTest.java
@@ -18,6 +18,7 @@ package org.commonjava.util.partyline;
 import org.commonjava.util.partyline.fixture.TimedFileWriter;
 import org.commonjava.util.partyline.fixture.TimedTask;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
@@ -48,9 +49,6 @@ public abstract class AbstractJointedIOTest
 
     @Rule
     public TestName name = new TestName();
-
-    @Rule
-    public TestRule timeout = timeoutRule( 30, TimeUnit.SECONDS );
 
     protected int readers = 0;
 

--- a/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
@@ -63,7 +63,8 @@ public class BinaryFileTest {
     }
 
     @Test
-    public void shouldReadBinaryFile() throws IOException
+    public void shouldReadBinaryFile()
+            throws IOException, InterruptedException
     {
         List<String> failures = new ArrayList<>();
 

--- a/src/test/java/org/commonjava/util/partyline/ConcurrentReadErrorsClearLocksTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ConcurrentReadErrorsClearLocksTest.java
@@ -16,7 +16,6 @@
 package org.commonjava.util.partyline;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
@@ -25,15 +24,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.commonjava.util.partyline.UtilThreads.reader;
+import static org.commonjava.util.partyline.UtilThreads.writer;
+
 @RunWith( BMUnitRunner.class )
 public class ConcurrentReadErrorsClearLocksTest
-        extends AbstractJointedIOTest
+        extends AbstractBytemanTest
 {
     /**
      * Test that locks for mutiple reads clear correctly. This will setup an script of events for
@@ -46,38 +46,6 @@ public class ConcurrentReadErrorsClearLocksTest
      */
     /*@formatter:off*/
     @BMRules( rules = {
-            // setup the rendezvous for all threads, which will mean everything waits until all threads are started.
-            @BMRule( name = "init rendezvous", targetClass = "JoinableFileManager",
-                     targetMethod = "<init>",
-                     targetLocation = "ENTRY",
-                     action = "createRendezvous(\"begin\", 4)" ),
-
-            // setup the pause for openOutputStream, which rendezvous with openInputStream calls, then
-            // waits for one openInputStream call to exit
-            @BMRule( name = "openOutputStream start", targetClass = "JoinableFileManager",
-                     targetMethod = "openOutputStream",
-                     targetLocation = "ENTRY",
-                     action = "debug(\"Waiting for READ to start.\"); "
-                             + "rendezvous(\"begin\"); "
-                             + "waitFor(\"reading\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() thread proceeding.\")" ),
-
-            // setup the rendezvous to wait for all threads to be ready before proceeding
-            @BMRule( name = "openInputStream start", targetClass = "JoinableFileManager",
-                     targetMethod = "openInputStream",
-                     targetLocation = "ENTRY",
-                     action = "debug(\"Waiting for ALL to start.\"); "
-                             + "rendezvous(\"begin\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() thread proceeding.\")" ),
-
-            // setup the trigger to signal openOutputStream when the first openInputStream exits
-            @BMRule( name = "openInputStream end", targetClass = "JoinableFileManager",
-                     targetMethod = "openInputStream",
-                     targetLocation = "EXCEPTION EXIT",
-                     action = "debug(\"Signal READ.\"); "
-                             + "signalWake(\"reading\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() done.\")" ),
-
             // When we try to init a new JoinableFile for INPUT, simulate an IOException from somewhere deeper in the stack.
             @BMRule( name = "new JoinableFile error", targetClass = "JoinableFile", targetMethod = "<init>",
                      targetLocation = "ENTRY",
@@ -95,47 +63,19 @@ public class ConcurrentReadErrorsClearLocksTest
         FileUtils.write( f, "test data" );
 
         final CountDownLatch latch = new CountDownLatch( 4 );
+
+        CountDownLatch readBeginLatch = new CountDownLatch( 3 );
+        CountDownLatch readEndLatch = new CountDownLatch( 3 );
+
         final JoinableFileManager manager = new JoinableFileManager();
         final long start = System.currentTimeMillis();
 
-        execs.execute( () -> {
-            Thread.currentThread().setName( "openOutputStream" );
-
-            try (OutputStream o = manager.openOutputStream( f ))
-            {
-                o.write( "Test data".getBytes() );
-            }
-            catch ( Exception e )
-            {
-                e.printStackTrace();
-            }
-            latch.countDown();
-            System.out.println(
-                    String.format( "[%s] Count down after write thread: %s", Thread.currentThread().getName(),
-                                   latch.getCount() ) );
-        } );
+        execs.execute( writer( manager, f, latch, readEndLatch ) );
 
         for ( int i = 0; i < 3; i++ )
         {
             final int k = i;
-            execs.execute( () -> {
-                Thread.currentThread().setName( "openInputStream-" + k );
-                try (InputStream s = manager.openInputStream( f ))
-                {
-                    System.out.println( IOUtils.toString( s ) );
-                }
-                catch ( Exception e )
-                {
-                    e.printStackTrace();
-                }
-                finally
-                {
-                    latch.countDown();
-                    System.out.println(
-                            String.format( "[%s] Count down after %s read thread: %s", Thread.currentThread().getName(),
-                                           k, latch.getCount() ) );
-                }
-            } );
+            execs.execute( reader(k, manager, f, latch, readBeginLatch, readEndLatch, null ) );
         }
 
         latch.await();

--- a/src/test/java/org/commonjava/util/partyline/ConcurrentReadWithOneErrorClearLocksTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ConcurrentReadWithOneErrorClearLocksTest.java
@@ -16,7 +16,6 @@
 package org.commonjava.util.partyline;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
@@ -25,15 +24,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.commonjava.util.partyline.UtilThreads.reader;
+import static org.commonjava.util.partyline.UtilThreads.writer;
+
 @RunWith( BMUnitRunner.class )
 public class ConcurrentReadWithOneErrorClearLocksTest
-        extends AbstractJointedIOTest
+        extends AbstractBytemanTest
 {
     /**
      * Test that locks for mutiple reads clear correctly. This will setup an script of events for
@@ -50,39 +50,12 @@ public class ConcurrentReadWithOneErrorClearLocksTest
             @BMRule( name = "init rendezvous", targetClass = "JoinableFileManager",
                      targetMethod = "<init>",
                      targetLocation = "ENTRY",
-                     action = "createRendezvous(\"begin\", 4); "
-                             + "createCountDown(\"join\", 2)" ),
-
-            // setup the pause for openOutputStream, which rendezvous with openInputStream calls, then
-            // waits for one openInputStream call to exit
-            @BMRule( name = "openOutputStream start", targetClass = "JoinableFileManager",
-                     targetMethod = "openOutputStream",
-                     targetLocation = "ENTRY",
-                     action = "debug(\"Waiting for DELETE.\"); " + "rendezvous(\"begin\"); "
-                             + "debug(\"Wait for READ\"); "
-                             + "waitFor(\"reading\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() thread proceeding.\")" ),
-
-            // setup the rendezvous to wait for all threads to be ready before proceeding
-            @BMRule( name = "openInputStream start", targetClass = "JoinableFileManager",
-                     targetMethod = "openInputStream",
-                     targetLocation = "ENTRY",
-                     action = "debug(\"Waiting for ALL to start.\"); "
-                             + "rendezvous(\"begin\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() thread proceeding.\")" ),
-
-            // setup the trigger to signal openOutputStream when the first openInputStream exits
-            @BMRule( name = "openInputStream end", targetClass = "JoinableFileManager",
-                     targetMethod = "openInputStream",
-                     targetLocation = "EXIT",
-                     action = "debug(\"Signal READ.\"); "
-                             + "signalWake(\"reading\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() done.\")" ),
+                     action = "createCountDown(\"JOIN\", 2)" ),
 
             // When we try to init a new JoinableFile for INPUT, simulate an IOException from somewhere deeper in the stack.
             @BMRule( name = "new JoinableFile error", targetClass = "JoinableFile", targetMethod = "joinStream",
                      targetLocation = "ENTRY",
-                     condition = "countDown(\"join\")",
+                     condition = "countDown(\"JOIN\")",
                      action = "debug(\"Throwing test exception in \" + Thread.currentThread().getName()); "
                              + "throw new java.io.IOException(\"Test exception\")" ) } )
     /*@formatter:on*/
@@ -97,45 +70,19 @@ public class ConcurrentReadWithOneErrorClearLocksTest
         FileUtils.write( f, "test data" );
 
         final CountDownLatch latch = new CountDownLatch( 4 );
+        CountDownLatch readBeginLatch = new CountDownLatch( 3 );
+        CountDownLatch readEndLatch = new CountDownLatch( 3 );
+
         final JoinableFileManager manager = new JoinableFileManager();
+        manager.startReporting( 5000, 5000 );
         final long start = System.currentTimeMillis();
 
-        execs.execute( () -> {
-            Thread.currentThread().setName( "openOutputStream" );
-
-            try (OutputStream o = manager.openOutputStream( f ))
-            {
-                o.write( "Test data".getBytes() );
-            }
-            catch ( Exception e )
-            {
-                e.printStackTrace();
-            }
-            latch.countDown();
-            System.out.println( String.format( "[%s] Count down after openOutputStream thread: %s",
-                                               Thread.currentThread().getName(), latch.getCount() ) );
-        } );
+        execs.execute( writer( manager, f, latch, readEndLatch ) );
 
         for ( int i = 0; i < 3; i++ )
         {
             final int k = i;
-            execs.execute( () -> {
-                Thread.currentThread().setName( "openInputStream-" + k );
-                try (InputStream s = manager.openInputStream( f ))
-                {
-                    System.out.println( Thread.currentThread().getName() + ": " + IOUtils.toString( s ) );
-                }
-                catch ( Exception e )
-                {
-                    e.printStackTrace();
-                }
-                finally
-                {
-                    latch.countDown();
-                    System.out.println( String.format( "[%s] Count down after openInputStream-%s read thread: %s",
-                                                       Thread.currentThread().getName(), k, latch.getCount() ) );
-                }
-            } );
+            execs.execute( reader(k, manager, f, latch, readBeginLatch, readEndLatch, null) );
         }
 
         latch.await();

--- a/src/test/java/org/commonjava/util/partyline/ConcurrentReadsClearLocksTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ConcurrentReadsClearLocksTest.java
@@ -16,7 +16,6 @@
 package org.commonjava.util.partyline;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
@@ -25,15 +24,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-@RunWith( BMUnitRunner.class )
+import static org.commonjava.util.partyline.UtilThreads.reader;
+import static org.commonjava.util.partyline.UtilThreads.writer;
+
 public class ConcurrentReadsClearLocksTest
-        extends AbstractJointedIOTest
+        extends AbstractBytemanTest
 {
     /**
      * Test that locks for mutiple reads clear correctly. This will setup an script of events for
@@ -44,42 +43,7 @@ public class ConcurrentReadsClearLocksTest
      * </ol>
      * @throws Exception
      */
-    /*@formatter:off*/
-    @BMRules( rules = {
-            // setup the rendezvous for all threads, which will mean everything waits until all threads are started.
-            @BMRule( name = "init rendezvous", targetClass = "JoinableFileManager",
-                     targetMethod = "<init>",
-                     targetLocation = "ENTRY",
-                     action = "createRendezvous(\"begin\", 4)" ),
-
-            // setup the pause for openOutputStream, which rendezvous with openInputStream calls, then
-            // waits for one openInputStream call to exit
-            @BMRule( name = "openOutputStream start", targetClass = "JoinableFileManager",
-                     targetMethod = "openOutputStream",
-                     targetLocation = "ENTRY",
-                     action = "debug(\"Waiting for READ to start.\"); "
-                             + "rendezvous(\"begin\"); "
-                             + "waitFor(\"reading\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() thread proceeding.\")" ),
-
-            // setup the rendezvous to wait for all threads to be ready before proceeding
-            @BMRule( name = "openInputStream start", targetClass = "JoinableFileManager",
-                     targetMethod = "openInputStream",
-                     targetLocation = "ENTRY",
-                     action = "debug(\"Waiting for ALL to start.\"); "
-                             + "rendezvous(\"begin\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() thread proceeding.\")" ),
-
-            // setup the trigger to signal openOutputStream when the first openInputStream exits
-            @BMRule( name = "openInputStream end", targetClass = "JoinableFileManager",
-                     targetMethod = "openInputStream",
-                     targetLocation = "EXIT",
-                     action = "debug(\"Signal READ.\"); "
-                             + "signalWake(\"reading\"); "
-                             + "debug(Thread.currentThread().getName() + \": openInputStream() done.\")" ) } )
-    /*@formatter:on*/
     @Test
-    @BMUnitConfig( debug = true )
     public void run()
             throws Exception
     {
@@ -88,47 +52,18 @@ public class ConcurrentReadsClearLocksTest
         FileUtils.write( f, "test data" );
 
         final CountDownLatch latch = new CountDownLatch( 4 );
+        CountDownLatch readBeginLatch = new CountDownLatch( 3 );
+        CountDownLatch readEndLatch = new CountDownLatch( 3 );
         final JoinableFileManager manager = new JoinableFileManager();
+        manager.startReporting( 5000, 5000 );
         final long start = System.currentTimeMillis();
 
-        execs.execute( () -> {
-            Thread.currentThread().setName( "openOutputStream" );
-
-            try (OutputStream o = manager.openOutputStream( f ))
-            {
-                o.write( "Test data".getBytes() );
-            }
-            catch ( Exception e )
-            {
-                e.printStackTrace();
-            }
-            latch.countDown();
-            System.out.println(
-                    String.format( "[%s] Count down after write thread: %s", Thread.currentThread().getName(),
-                                   latch.getCount() ) );
-        } );
+        execs.execute( writer( manager, f, latch, readEndLatch ) );
 
         for ( int i = 0; i < 3; i++ )
         {
             final int k = i;
-            execs.execute( () -> {
-                Thread.currentThread().setName( "openInputStream-" + k );
-                try (InputStream s = manager.openInputStream( f ))
-                {
-                    System.out.println( IOUtils.toString( s ) );
-                }
-                catch ( Exception e )
-                {
-                    e.printStackTrace();
-                }
-                finally
-                {
-                    latch.countDown();
-                    System.out.println(
-                            String.format( "[%s] Count down after %s read thread: %s", Thread.currentThread().getName(),
-                                           k, latch.getCount() ) );
-                }
-            } );
+            execs.execute( reader(k, manager, f, latch, readBeginLatch, readEndLatch, null) );
         }
 
         latch.await();

--- a/src/test/java/org/commonjava/util/partyline/FileTreeTest.java
+++ b/src/test/java/org/commonjava/util/partyline/FileTreeTest.java
@@ -45,7 +45,7 @@ public class FileTreeTest
     {
         FileTree root = new FileTree();
         File child = createStructure( "child.txt", true );
-        JoinableFile jf = root.setOrJoinFile( child, null, false, -1, TimeUnit.MILLISECONDS );
+        JoinableFile jf = root.setOrJoinFile( child, null, false, -1, TimeUnit.MILLISECONDS, (result)->result );
 //        JoinableFile jf = new JoinableFile( child, false );
 //        root.add( jf );
 

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
@@ -119,14 +119,18 @@ public class JoinableFileManagerTest
             throws Exception
     {
         final File f = temp.newFile();
+        Thread.currentThread().setName( "output 1" );
         final OutputStream stream = mgr.openOutputStream( f );
 
+        Thread.currentThread().setName( "output 2" );
         OutputStream s2 = mgr.openOutputStream( f, SHORT_TIMEOUT );
 
         assertThat( s2, nullValue() );
 
+        Thread.currentThread().setName( "output 1" );
         stream.close();
 
+        Thread.currentThread().setName( "output 3" );
         s2 = mgr.openOutputStream( f, SHORT_TIMEOUT );
 
         assertThat( s2, notNullValue() );

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
@@ -20,7 +20,9 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.util.partyline.fixture.TimedTask;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import static org.commonjava.util.partyline.fixture.ThreadDumper.timeoutRule;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -40,6 +44,9 @@ public class JoinableFileManagerTest
 {
 
     private static final long SHORT_TIMEOUT = 10;
+
+    @Rule
+    public TestRule timeout = timeoutRule( 30, TimeUnit.SECONDS );
 
     private final JoinableFileManager mgr = new JoinableFileManager();
 

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
@@ -17,6 +17,7 @@ package org.commonjava.util.partyline;
 
 import static org.commonjava.util.partyline.LockLevel.read;
 import static org.commonjava.util.partyline.LockLevel.write;
+import static org.commonjava.util.partyline.fixture.ThreadDumper.timeoutRule;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import ch.qos.logback.core.util.FileSize;
 import org.apache.commons.io.FileUtils;
@@ -39,13 +41,18 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.util.partyline.fixture.TimedTask;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JoinableFileTest
     extends AbstractJointedIOTest
 {
+
+    @Rule
+    public TestRule timeout = timeoutRule( 30, TimeUnit.SECONDS );
 
     @Test
     public void readExistingFile()
@@ -83,7 +90,7 @@ public class JoinableFileTest
     }
 
     private void assertReadOfExistingFileOfSize( String s )
-            throws IOException
+            throws IOException, InterruptedException
     {
         File f = temp.newFile( "read-target.txt" );
         int sz = (int) FileSize.valueOf( "11mb" ).getSize();
@@ -151,7 +158,7 @@ public class JoinableFileTest
 
     @Test( expected = IOException.class )
     public void lockDirectoryJoinFails()
-            throws IOException
+            throws IOException, InterruptedException
     {
         File dir = temp.newFolder();
         dir.mkdirs();

--- a/src/test/java/org/commonjava/util/partyline/TwoConcurrentReadsTest.java
+++ b/src/test/java/org/commonjava/util/partyline/TwoConcurrentReadsTest.java
@@ -44,11 +44,8 @@ import static org.junit.Assert.assertThat;
 @RunWith( org.jboss.byteman.contrib.bmunit.BMUnitRunner.class )
 @BMUnitConfig( loadDirectory = "target/test-classes/bmunit", debug = true )
 public class TwoConcurrentReadsTest
-        extends AbstractJointedIOTest
+        extends AbstractBytemanTest
 {
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
-
     private final ExecutorService testPool = Executors.newFixedThreadPool( 2 );
 
     private final CountDownLatch latch = new CountDownLatch( 2 );

--- a/src/test/java/org/commonjava/util/partyline/UtilThreads.java
+++ b/src/test/java/org/commonjava/util/partyline/UtilThreads.java
@@ -1,0 +1,153 @@
+package org.commonjava.util.partyline;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Created by jdcasey on 12/8/16.
+ */
+public final class UtilThreads
+{
+    private UtilThreads(){}
+
+    public static Runnable writer( JoinableFileManager manager, File f, CountDownLatch masterLatch )
+    {
+        return writer( manager, f, masterLatch, null );
+    }
+
+    public static Runnable writer( JoinableFileManager manager, File f, CountDownLatch masterLatch, CountDownLatch readEndLatch )
+    {
+        return () -> {
+            Thread.currentThread().setName( "openOutputStream" );
+            System.out.println("Starting: " + Thread.currentThread().getName());
+
+            if ( readEndLatch != null )
+            {
+                try
+                {
+                    System.out.println("awaiting read-end latch");
+                    readEndLatch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    return;
+                }
+            }
+
+            try (OutputStream o = manager.openOutputStream( f ))
+            {
+                o.write( "Test data".getBytes() );
+            }
+            catch ( Exception e )
+            {
+                e.printStackTrace();
+            }
+            System.out.println("Counting down master latch");
+            masterLatch.countDown();
+            System.out.println(
+                    String.format( "[%s] Count down after write thread: %s", Thread.currentThread().getName(),
+                                   masterLatch.getCount() ) );
+        };
+    }
+
+    public static Runnable reader( int k, JoinableFileManager manager, File f, CountDownLatch masterLatch )
+    {
+        return reader( k, manager, f, masterLatch, null, null, null );
+    }
+
+    public static Runnable reader( int k, JoinableFileManager manager, File f, CountDownLatch masterLatch, CountDownLatch readEndLatch, CountDownLatch readBeginLatch, CountDownLatch deleteEndLatch )
+    {
+        return () -> {
+            Thread.currentThread().setName( "openInputStream-" + k );
+            System.out.println("Starting: " + Thread.currentThread().getName());
+
+            if ( deleteEndLatch != null )
+            {
+                try
+                {
+                    System.out.println("awaiting delete latch");
+                    deleteEndLatch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    return;
+                }
+            }
+
+            if ( readBeginLatch != null )
+            {
+                System.out.println("Counting down read-begin latch");
+                readBeginLatch.countDown();
+                try
+                {
+                    System.out.println("awaiting read-begin latch");
+                    readBeginLatch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    return;
+                }
+            }
+
+            try (InputStream s = manager.openInputStream( f ))
+            {
+                System.out.println( Thread.currentThread().getName() + ": " + IOUtils.toString( s ) );
+            }
+            catch ( Exception e )
+            {
+                e.printStackTrace();
+            }
+            finally
+            {
+                if ( readEndLatch != null )
+                {
+                    System.out.println("Counting down read-end latch");
+                    readEndLatch.countDown();
+                }
+                System.out.println("Counting down master latch");
+                masterLatch.countDown();
+                System.out.println(
+                        String.format( "[%s] Count down after %s read thread: %s", Thread.currentThread().getName(), k,
+                                       masterLatch.getCount() ) );
+            }
+        };
+    }
+
+    public static Runnable deleter( JoinableFileManager manager, File f, CountDownLatch masterLatch )
+    {
+        return deleter( manager, f, masterLatch, null );
+    }
+
+    public static Runnable deleter( JoinableFileManager manager, File f, CountDownLatch masterLatch, CountDownLatch deleteEndLatch )
+    {
+        return () -> {
+            Thread.currentThread().setName( "delete" );
+            System.out.println("Starting: " + Thread.currentThread().getName());
+            try
+            {
+                manager.tryDelete( f );
+            }
+            catch ( Exception e )
+            {
+                e.printStackTrace();
+            }
+            finally
+            {
+                if ( deleteEndLatch != null )
+                {
+                    System.out.println("Counting down delete latch");
+                    deleteEndLatch.countDown();
+                }
+                System.out.println("Counting down master latch");
+                masterLatch.countDown();
+                System.out.println(
+                        String.format( "[%s] Count down after delete thread: %s", Thread.currentThread().getName(),
+                                       masterLatch.getCount() ) );
+            }
+        };
+    }
+}

--- a/src/test/java/org/commonjava/util/partyline/fixture/ThreadDumper.java
+++ b/src/test/java/org/commonjava/util/partyline/fixture/ThreadDumper.java
@@ -123,7 +123,14 @@ public final class ThreadDumper
                     {
                         System.out.printf( "Test timeout %d %s expired!\n", timeout, units.name() );
                         dumpThreads();
-                        fail( String.format( "Test timed out after %d %s", timeout, units ) );
+                        StackTraceElement[] stackTrace = t.getStackTrace();
+                        Exception currThreadException = new TestTimedOutException(timeout, units);
+                        if (stackTrace != null) {
+                            currThreadException.setStackTrace(stackTrace);
+                            t.interrupt();
+                        }
+
+                        throw currThreadException;
                     }
                 }
 


### PR DESCRIPTION
… to avoid race condition. Fix ThreadDumper's timeout rule