### PR TITLE
JoinableFileManager - Failed to close in Indy log

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -240,7 +240,12 @@ public final class JoinableFile
         {
             opLock.lockAnd( (lock)->{
                 Logger logger = LoggerFactory.getLogger( getClass() );
-                logger.trace( "close() called, marking as closed..." );
+                if ( closed )
+                {
+                    logger.trace( "close() called, but is already closed." );
+                    return null;
+                }
+                logger.trace( "close() called, marking as closed." );
 
                 closed = true;
 
@@ -596,6 +601,11 @@ public final class JoinableFile
         {
             Logger logger = LoggerFactory.getLogger( getClass() );
             logger.trace( "Joint: {} close() called.", jointIdx );
+            if ( closed )
+            {
+                logger.trace( "Joint: {} already closed.", jointIdx );
+                return;
+            }
             closed = true;
             super.close();
             jointClosed( this, originalThreadName );


### PR DESCRIPTION
Add a boolean reallyClosed to JoinableFile to prevent unintended multiple reallyClose being called. This can happen when an Indy thread really closes a file but the relevant input stream calls jointClose again when cleaning threadContext. 