### PR TITLE
Improve concurrency when callers race to be first to open read stream.

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
+++ b/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
@@ -46,17 +46,21 @@ final class FileOperationLock
             logger.trace( "Locking: {} for: {} from:\n\n{}\n\n", this, Thread.currentThread().getName(), join( Thread.currentThread().getStackTrace(), "\n  " ) );
         }
 
-        boolean result = lock.tryLock(timeout, unit);
-        if ( result )
-        {
-            this.locker = Thread.currentThread().getName();
-        }
-        return result;
+        lock.lockInterruptibly();
+//        boolean result = lock.tryLock(timeout, unit);
+//        if ( result )
+//        {
+//            this.locker = Thread.currentThread().getName();
+//        }
+//        return result;
+
+        logger.trace( "Lock established." );
+        return true;
     }
 
     public void unlock()
     {
-        if ( lock.isLocked() )
+        if ( lock.isHeldByCurrentThread() )
         {
             Logger logger = LoggerFactory.getLogger( getClass() );
             if ( logger.isTraceEnabled() )
@@ -66,6 +70,8 @@ final class FileOperationLock
 
             lock.unlock();
             locker = null;
+
+            logger.trace( "Locked released" );
         }
     }
 
@@ -82,7 +88,7 @@ final class FileOperationLock
 
     public void signal()
     {
-        if ( lock.isLocked() )
+        if ( lock.isHeldByCurrentThread() )
         {
             Logger logger = LoggerFactory.getLogger( getClass() );
             logger.trace( "Signal from: {} in lock of: {} (locked by: {})", Thread.currentThread().getName(), this, locker );

--- a/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
+++ b/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
@@ -37,22 +37,17 @@ final class FileOperationLock
 
     private String locker;
 
-    public boolean lock( long timeout, TimeUnit unit )
+    public boolean lock()
             throws InterruptedException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
         if ( logger.isTraceEnabled() )
         {
-            logger.trace( "Locking: {} for: {} from:\n\n{}\n\n", this, Thread.currentThread().getName(), join( Thread.currentThread().getStackTrace(), "\n  " ) );
+            logger.trace( "Locking: {} for: {} from:\n\n{}\n\n", this, Thread.currentThread().getName(),
+                          join( Thread.currentThread().getStackTrace(), "\n  " ) );
         }
 
         lock.lockInterruptibly();
-//        boolean result = lock.tryLock(timeout, unit);
-//        if ( result )
-//        {
-//            this.locker = Thread.currentThread().getName();
-//        }
-//        return result;
 
         logger.trace( "Lock established." );
         return true;
@@ -68,6 +63,7 @@ final class FileOperationLock
                 logger.trace( "Locking: {} (locked by: {}) from:\n\n{}\n\n", this, locker, join( Thread.currentThread().getStackTrace(), "\n  " ) );
             }
 
+            changed.signal();
             lock.unlock();
             locker = null;
 

--- a/src/main/java/org/commonjava/util/partyline/FileTree.java
+++ b/src/main/java/org/commonjava/util/partyline/FileTree.java
@@ -36,7 +36,9 @@ import java.util.stream.Stream;
 import static org.commonjava.util.partyline.LockLevel.read;
 
 /**
- * Created by jdcasey on 8/18/16.
+ * Maintains access to files in partyline. This class restricts operations to prohibit concurrent operations on the same
+ * path at the same time, where 'operation' means opening a file, deleting a file, or locking/unlocking a file. It also
+ * provides methods for extracting or logging information about the file locks that are currently active.
  */
 final class FileTree
 {
@@ -49,11 +51,22 @@ final class FileTree
 
     private final Map<String, FileOperationLock> operationLocks = new ConcurrentHashMap<>();
 
+    /**
+     * Iterate all {@link FileEntry instances} to extract information about active locks.
+     *
+     * @param fileConsumer The operation to extract information from a single active file.
+     */
     void forAll( Consumer<JoinableFile> fileConsumer )
     {
         forAll( entry -> entry.file != null, entry->fileConsumer.accept( entry.file ) );
     }
 
+    /**
+     * Iterate all {@link FileEntry instances} to extract information about active locks.
+     *
+     * @param predicate The selector determining which files to analyze.
+     * @param fileConsumer The operation to extract information from a single active file.
+     */
     void forAll( Predicate<? super FileEntry> predicate, Consumer<FileEntry> fileConsumer )
     {
         TreeMap<String, FileEntry> sorted = new TreeMap<>( entryMap );
@@ -65,6 +78,9 @@ final class FileTree
         } );
     }
 
+    /**
+     * Render the active files as a tree structure, for output to a log file or other string-oriented output.
+     */
     String renderTree()
     {
         StringBuilder sb = new StringBuilder();
@@ -86,6 +102,12 @@ final class FileTree
         return sb.toString();
     }
 
+    /**
+     * Retrieve the {@link LockLevel} for the given file. This corresponds to the highest level of access currently
+     * granted for this file.
+     *
+     * @see LockLevel
+     */
     LockLevel getLockLevel( File file )
     {
         FileEntry entry = getLockingEntry( file );
@@ -103,6 +125,13 @@ final class FileTree
         }
     }
 
+    /**
+     * (Manually) unlock a file for a given ownership label. The label allows the system to avoid unlocking for other
+     * active threads that might still be using the file.
+     * @param f The file to unlock
+     * @param ownerName The ownership label to remove from the active locks on the file
+     * @return true if the file has no remaining locks after unlocking for this owner; false otherwise
+     */
     boolean unlock( File f, String ownerName )
     {
         try
@@ -112,8 +141,6 @@ final class FileTree
                 FileEntry entry = entryMap.get( f.getAbsolutePath() );
                 if ( entry != null )
                 {
-                    //            synchronized ( entry )
-                    //            {
                     logger.trace( "Unlocking {} (owner: {})", f, ownerName );
                     if ( entry.lock.unlock( ownerName ) )
                     {
@@ -127,16 +154,17 @@ final class FileTree
 
                         entryMap.remove( entry.name );
 
-                        //                    entry.notifyAll();
                         opLock.signal();
                         logger.trace( "Unlock succeeded." );
                         return true;
                     }
                     else
                     {
-                        logger.trace( "{} Unlock request failed: Remaining locks:\n\n{}", ownerName, entry.lock.getLockInfo() );
+                        logger.trace( "{} Request did not completely unlock file. Remaining locks:\n\n{}", ownerName,
+                                      entry.lock.getLockInfo() );
+                        opLock.signal();
+                        return false;
                     }
-                    //            }
                 }
                 else
                 {
@@ -144,8 +172,7 @@ final class FileTree
                 }
 
                 opLock.signal();
-                logger.trace( "Unlock failed." );
-                return false;
+                return true;
             } );
         }
         catch ( IOException e )
@@ -162,17 +189,27 @@ final class FileTree
         return false;
     }
 
-    private boolean clearLocks( File f )
+    /**
+     * In certain cases, when an operation completes we cannot retain any locks on the file. This method clears all
+     * remaining locks and releases the file from the active-locked mapping. The cases where this is important:
+     *
+     * <ul>
+     *     <li>When the entire {@link JoinableFile} instance (which manages read and write operations) is closing</li>
+     *     <li>When the completing operation locked a file for deletion</li>
+     *     <li>When we've just established the first lock on a file, then the operation acquiring this lock fails.</li>
+     * </ul>
+     *
+     * @param f The file whose locks should be cleared
+     */
+    private void clearLocks( File f )
     {
         try
         {
-            return withOpLock( f, ( opLock ) -> {
+            withOpLock( f, ( opLock ) -> {
                 Logger logger = LoggerFactory.getLogger( getClass() );
                 FileEntry entry = entryMap.get( f.getAbsolutePath() );
                 if ( entry != null )
                 {
-                    //            synchronized ( entry )
-                    //            {
                     logger.trace( "Unlocking {}", f );
                     entry.lock.clearLocks();
                     logger.trace( "Unlocked; clearing resources associated with lock" );
@@ -184,12 +221,13 @@ final class FileTree
                     }
 
                     entryMap.remove( entry.name );
+                    synchronized ( operationLocks )
+                    {
+                        operationLocks.remove( f.getAbsolutePath() );
+                    }
 
-                    //                    entry.notifyAll();
                     opLock.signal();
                     logger.trace( "Unlock succeeded." );
-                    return true;
-                    //            }
                 }
                 else
                 {
@@ -197,8 +235,7 @@ final class FileTree
                 }
 
                 opLock.signal();
-                logger.trace( "Unlock failed." );
-                return false;
+                return null;
             } );
         }
         catch ( IOException e )
@@ -211,10 +248,24 @@ final class FileTree
             Logger logger = LoggerFactory.getLogger( getClass() );
             logger.warn( "Interrupted while trying to unlock: " + f );
         }
-
-        return false;
     }
 
+    /**
+     * Acquire the given {@link LockLevel} on the specified file, under the provided ownership name and activity label,
+     * within the given timeout. This is used to manually lock a file from outside.
+     *
+     * @param file The file to lock
+     * @param ownerName The owner name to use, when tracking / releasing active locks
+     * @param label The activity label, to aid in debugging stuck locks
+     * @param lockLevel The type of lock to acquire (read, write, delete)
+     * @param timeout The timeout period before giving up on the lock acquisition
+     * @param unit The time units for the timeout period (milliseconds, etc)
+     * @return true if the file was locked as specified, otherwise false
+     * @throws InterruptedException
+     *
+     * @see JoinableFileManager#lock(File, long, LockLevel, String)
+     * @see LockLevel
+     */
     boolean tryLock( File file, String ownerName, String label, LockLevel lockLevel, long timeout, TimeUnit unit )
             throws InterruptedException
     {
@@ -231,6 +282,29 @@ final class FileTree
         return false;
     }
 
+    /**
+     * Acquire the given {@link LockLevel} on the specified file, under the provided ownership name and activity label,
+     * within the given timeout. If lock acquisition succeeds, execute the provided operation (normally a lambda).
+     * <br/>
+     * This method is used within FileTree to handle file lock acquisition before opening / deleting files, among other
+     * things.
+     * <br/>
+     * <b>NOTE:</b> Before attempting to acquire the file lock, this method will acquire the operation semaphore for
+     * the given file. This prevents other concurrent calls from overlapping when establishing the first lock on a file,
+     * or when releasing the last lock.
+     *
+     * @param f The file to lock
+     * @param ownerName The owner name to use, when tracking / releasing active locks
+     * @param label The activity label, to aid in debugging stuck locks
+     * @param lockLevel The type of lock to acquire (read, write, delete)
+     * @param timeout The timeout period before giving up on the lock acquisition
+     * @param unit The time units for the timeout period (milliseconds, etc)
+     * @param operation The operation to perform once the file lock is acquired
+     * @return the result of the provided operation, or else null
+     * @throws InterruptedException
+     *
+     * @see LockLevel
+     */
     private <T> T tryLock( File f, String ownerName, String label, LockLevel lockLevel, long timeout, TimeUnit unit,
                            LockedFileOperation<T> operation )
             throws InterruptedException, IOException
@@ -272,8 +346,6 @@ final class FileTree
                     }
                     else
                     {
-                        //                synchronized ( entry )
-                        //                {
                         if ( entry.name.equals( f.getAbsolutePath() ) )
                         {
                             if ( entry.lock.lock( ownerName, label, lockLevel ) )
@@ -297,9 +369,7 @@ final class FileTree
                         }
 
                         logger.trace( "Waiting for lock to clear; locking as: {} from: {}", lockLevel, label );
-                        //                    entry.wait( 100 );
                         opLock.await( WAIT_TIMEOUT );
-                        //                }
                     }
                 }
             }
@@ -318,6 +388,27 @@ final class FileTree
         } );
     }
 
+    /**
+     * Establish a Stream (input or output) associated with a given file. This method will acquire the appropriate lock
+     * for the file (using {@link #tryLock(File, String, String, LockLevel, long, TimeUnit, LockedFileOperation)}) and
+     * then retrieve the {@link JoinableFile} instance associated with the file (or create it if necessary). Finally,
+     * it passes the JoinableFile to the given {@link JoinFileOperation} to establish the appropriate stream into / out
+     * of that file.
+     *
+     * @param realFile The file to open
+     * @param callbacks A set of callback operations that can respond to the file being closed or flushed, normally
+     *                  used for accounting.
+     * @param doOutput If true, the associated function should return an {@link java.io.OutputStream}; else {@link java.io.InputStream}
+     * @param timeout The period to wait in attempting to acquire the appropriate file lock
+     * @param unit The time unit for the timeout period
+     * @param function The function that establishes the appropriate stream into the {@link JoinableFile}
+     * @param <T> The type of stream returned from the given {@link JoinFileOperation}; output if doOutput is true, else input
+     * @return The established stream associated with the given file
+     * @throws IOException
+     * @throws InterruptedException
+     *
+     * @see #tryLock(File, String, String, LockLevel, long, TimeUnit, LockedFileOperation)
+     */
     <T> T setOrJoinFile( File realFile, StreamCallbacks callbacks, boolean doOutput, long timeout,
                                 TimeUnit unit, JoinFileOperation<T> function )
             throws IOException, InterruptedException
@@ -389,6 +480,19 @@ final class FileTree
         return function.execute( null );
     }
 
+    /**
+     * Attempt to establish a delete lock on the given file, then delete it. Timeout if the specified period expires
+     * without delete lock acquisition.
+     *
+     * @param file The file to lock
+     * @param timeout The period to wait for a delete lock
+     * @param unit The time unit for the timeout period
+     * @return true if the delete lock was successful and the file was force-deleted; false otherwise
+     * @throws InterruptedException
+     * @throws IOException
+     *
+     * @see #tryLock(File, String, String, LockLevel, long, TimeUnit, LockedFileOperation)
+     */
     boolean delete( File file, long timeout, TimeUnit unit )
             throws InterruptedException, IOException
     {
@@ -408,6 +512,19 @@ final class FileTree
         } ) == Boolean.TRUE;
     }
 
+    /**
+     * When trying to lock a file, we first must ensure that no directory further up the hierarchy is already locked with
+     * a more restrictive lock. If we're trying to lock a directory, we also must ensure that no child directory/file
+     * is locked with a more restrictive lock. This method checks for those cases, and returns the {@link FileEntry}
+     * from the ancestry or descendent files/directories that is already locked.
+     *
+     * This should prevent us from deleting a directory when a child file within that directory structure is being read
+     * or written. Likewise, it should prevent us from reading or writing a file in a directory already locked for
+     * deletion.
+     *
+     * @param file The file whose context directories / files should be checked for locks
+     * @return The nearest {@link FileEntry}, corresponding to a locked file. Parent directories returned before children.
+     */
     private synchronized FileEntry getLockingEntry( File file )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
@@ -448,6 +565,25 @@ final class FileTree
         return null;
     }
 
+    /**
+     * Use a {@link java.util.concurrent.locks.ReentrantLock} keyed to the absolute path of the specified file to ensure
+     * only one operation at a time manipulates the accounting information associated with the file ({@link FileEntry}).
+     *
+     * This method synchronizes on the operationLocks map in order to retrieve / create the ReentrantLock lazily. Once
+     * created, this ReentrantLock also gets propagated into the {@link JoinableFile} instance created for the file.
+     *
+     * Using ReentrantLock per path avoids the need to hold a lock on the whole tree every time we need to initialize
+     * the {@link FileEntry} for a new file. Instead, we take a short lock on operationLocks to get the ReentrantLock,
+     * then use the ReentrantLock for the longer operations required to initialize a file, open a stream, delete a file,
+     * close a file, etc.
+     *
+     * @param f The file that is the subject of the operation we want to execute
+     * @param op The operation to execute, once we've locked the ReentrantLock associated with the file
+     * @param <T> The result type of the specified operation
+     * @return the result of the specified operation
+     * @throws IOException
+     * @throws InterruptedException
+     */
     private <T> T withOpLock( File f, LockedFileOperation<T> op )
             throws IOException, InterruptedException
     {
@@ -455,7 +591,6 @@ final class FileTree
         String path = f.getAbsolutePath();
         FileOperationLock opLock = null;
 
-//        boolean locked = false;
         try
         {
             synchronized ( operationLocks )
@@ -472,22 +607,19 @@ final class FileTree
 
             }
 
-            if ( !opLock.lock( DEFAULT_LOCK_TIMEOUT, TimeUnit.MILLISECONDS ) )
+            if ( !opLock.lock() )
             {
                 throw new IOException(
                         "Failed to acquire operational lock for: " + path + " using opLock: " + opLock
                                 + " (currently locked by: " + opLock.getLocker() + ")" );
             }
 
-            //                locked = true;
             logger.trace( "Locked FileOperationLock: {} for path: {}. Proceeding with file operation.", opLock, path );
 
             return op.execute( opLock );
         }
         finally
         {
-            //            if ( locked )
-            //            {
             try
             {
                 opLock.unlock();
@@ -496,10 +628,14 @@ final class FileTree
             {
                 logger.error( "Failed to unlock: " + path, t );
             }
-            //            }
         }
     }
 
+    /**
+     * Class which manages the state associated with files and {@link JoinableFile}s in partyline. These keep the lock
+     * associated with a path and a {@link JoinableFile}, even when there is no JoinableFile yet. They are mapped to the
+     * path to allow concurrent operations to access this state and open additional (reader) streams, etc.
+     */
     static final class FileEntry
     {
         private final String name;
@@ -515,6 +651,10 @@ final class FileTree
         }
     }
 
+    /**
+     * {@link StreamCallbacks} implementation which can wrap another instance passed into {@link FileTree} operations,
+     * and which takes care of clearing all locks on a file when the {@link JoinableFile} is finally closed.
+     */
     private final class FileTreeCallbacks
             implements StreamCallbacks
     {
@@ -547,13 +687,6 @@ final class FileTree
             {
                 callbacks.beforeClose();
             }
-
-            //            synchronized( entry )
-            //            {
-            //                //            FileTree.this.lock.lock();
-            //                entry.file = null;
-            //                //            FileTree.this.lock.unlock();
-            //            }
         }
 
         @Override
@@ -569,11 +702,24 @@ final class FileTree
 
             // already inside lock from JoinableFile.reallyClose().
             entry.file = null;
+
+            // the whole JoinableFile is closing. Clear remaining locks.
             clearLocks( file );
         }
     }
 
-     @FunctionalInterface
+    /**
+     * Operation that returns a stream (InputStream or OutputStream) from a {@link JoinableFile}. This is used from
+     * {@link JoinableFileManager#openInputStream(File, long)} and {@link JoinableFileManager#openOutputStream(File, long)}
+     * via {@link FileTree#setOrJoinFile(File, StreamCallbacks, boolean, long, TimeUnit, JoinFileOperation)}.
+     *
+     * @param <T> The stream result.
+     *
+     * @see JoinableFileManager#openInputStream(File, long)
+     * @see JoinableFileManager#openOutputStream(File, long)
+     * @see FileTree#setOrJoinFile(File, StreamCallbacks, boolean, long, TimeUnit, JoinFileOperation)
+     */
+    @FunctionalInterface
     interface JoinFileOperation<T>
     {
         T execute( JoinableFile file )

--- a/src/main/java/org/commonjava/util/partyline/FileTree.java
+++ b/src/main/java/org/commonjava/util/partyline/FileTree.java
@@ -221,10 +221,6 @@ final class FileTree
                     }
 
                     entryMap.remove( entry.name );
-                    synchronized ( operationLocks )
-                    {
-                        operationLocks.remove( f.getAbsolutePath() );
-                    }
 
                     opLock.signal();
                     logger.trace( "Unlock succeeded." );

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.io.SyncFailedException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
@@ -67,7 +68,7 @@ public final class JoinableFile
 
     private final FileChannel channel;
 
-    private final FileLock fileLock;
+//    private final FileLock fileLock;
 
     private final JoinableOutputStream output;
 
@@ -135,7 +136,7 @@ public final class JoinableFile
                 output = null;
                 randomAccessFile = null;
                 channel = null;
-                fileLock = null;
+//                fileLock = null;
                 joinable = false;
             }
             else if ( doOutput )
@@ -144,7 +145,7 @@ public final class JoinableFile
                 output = new JoinableOutputStream();
                 randomAccessFile = new RandomAccessFile( target, "rws" );
                 channel = randomAccessFile.getChannel();
-                fileLock = channel.lock( 0L, Long.MAX_VALUE, false );
+//                fileLock = channel.lock( 0L, Long.MAX_VALUE, false );
             }
             else
             {
@@ -154,7 +155,7 @@ public final class JoinableFile
                 flushed = target.length();
                 randomAccessFile = new RandomAccessFile( target, "r" );
                 channel = randomAccessFile.getChannel();
-                fileLock = channel.lock( 0L, Long.MAX_VALUE, true );
+//                fileLock = channel.lock( 0L, Long.MAX_VALUE, true );
             }
         }
         catch ( OverlappingFileLockException e )
@@ -336,7 +337,7 @@ public final class JoinableFile
                     {
                         if ( channel.isOpen() )
                         {
-                            fileLock.release();
+//                            fileLock.release();
                             channel.close();
                         }
                         else
@@ -345,6 +346,11 @@ public final class JoinableFile
                         }
 
                         randomAccessFile.close();
+                        randomAccessFile.getFD().sync();
+                    }
+                    catch ( SyncFailedException e )
+                    {
+                        logger.warn( "System buffers MAY NOT be flushed for closed file: " + path, e );
                     }
                     catch ( ClosedChannelException e )
                     {

--- a/src/main/java/org/commonjava/util/partyline/LockLevel.java
+++ b/src/main/java/org/commonjava/util/partyline/LockLevel.java
@@ -16,7 +16,17 @@
 package org.commonjava.util.partyline;
 
 /**
- * Created by jdcasey on 10/3/16.
+ * Enumerates the types of locks that are allowed on files in partyline. File locks are <b>SOMETIMES</b> non-exclusive.
+ * This locking approach is aimed at allowing concurrent reads, even when a file is currently being written (the entire
+ * purpose of partyline).
+ * <br/>
+ * Lock exclusivity follows these rules:
+ * <ul>
+ *     <li>delete locks are exclusive</li>
+ *     <li>write locks allow concurrent read locks, but <b>not</b> delete locks or other write locks</li>
+ *     <li>a read lock established <b>as the first lock on the stream</b> prohibits both delete and write locks</li>
+ *     <li>read locks allow concurrent read locks</li>
+ * </ul>
  */
 public enum LockLevel
 {

--- a/src/main/java/org/commonjava/util/partyline/LockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/LockOwner.java
@@ -37,25 +37,28 @@ final class LockOwner
 
     private final Map<String, String> lockRefs = new LinkedHashMap<>();
 
+    private String path;
+
     private final LockLevel lockLevel;
 
-    LockOwner( String ownerName, String label, LockLevel lockLevel )
+    LockOwner( String path, String ownerName, String label, LockLevel lockLevel )
     {
+        this.path = path;
         this.lockLevel = lockLevel;
 
         final Thread t = Thread.currentThread();
         this.threadRef = new WeakReference<>( t );
         this.threadName = t.getName() + "(" + label + ")";
         this.threadId = t.getId();
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        if ( logger.isDebugEnabled() )
-        {
-            this.lockOrigin = t.getStackTrace();
-        }
-        else
-        {
-            this.lockOrigin = null;
-        }
+//        Logger logger = LoggerFactory.getLogger( getClass() );
+//        if ( logger.isDebugEnabled() )
+//        {
+//            this.lockOrigin = t.getStackTrace();
+//        }
+//        else
+//        {
+//            this.lockOrigin = null;
+//        }
 
         increment( ownerName, label );
     }
@@ -117,7 +120,7 @@ final class LockOwner
     @Override
     public String toString()
     {
-        return String.format( "LockOwner [%s]\n  %s", super.hashCode(),
+        return String.format( "LockOwner [%s] of: %s\n\nOrigin: %s", super.hashCode(), path,
                               lockOrigin == null ? "-suppressed-" : join( lockOrigin, "\n  " ) );
     }
 

--- a/src/main/java/org/commonjava/util/partyline/callback/CallbackInputStream.java
+++ b/src/main/java/org/commonjava/util/partyline/callback/CallbackInputStream.java
@@ -19,6 +19,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+@Deprecated
 public class CallbackInputStream
     extends FilterInputStream
 {

--- a/src/main/java/org/commonjava/util/partyline/callback/CallbackOutputStream.java
+++ b/src/main/java/org/commonjava/util/partyline/callback/CallbackOutputStream.java
@@ -19,6 +19,7 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+@Deprecated
 public class CallbackOutputStream
     extends FilterOutputStream
 {

--- a/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
@@ -70,7 +70,8 @@ public class BinaryFileTest {
 
         File binaryFile = temp.newFile( "binary-file.bin" );
         ReentrantLock lock = new ReentrantLock();
-        JoinableFile jf = new JoinableFile( binaryFile, new LockOwner( Thread.currentThread().getName(), name.getMethodName(), LockLevel.write ), true );
+        JoinableFile jf = new JoinableFile( binaryFile, new LockOwner( binaryFile.getAbsolutePath(), Thread.currentThread().getName(),
+                                                                         name.getMethodName(), LockLevel.write ), true );
         OutputStream jos = jf.getOutputStream();
         InputStream actual = jf.joinStream();
 

--- a/src/test/java/org/commonjava/util/partyline/ConcurrentFirstReaderTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ConcurrentFirstReaderTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.util.partyline;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.commonjava.util.partyline.UtilThreads.reader;
+import static org.commonjava.util.partyline.UtilThreads.writer;
+
+@RunWith( BMUnitRunner.class )
+public class ConcurrentFirstReaderTest
+        extends AbstractJointedIOTest
+{
+    /**
+     * GIVEN:
+     * <ol>
+     *     <li>File exists on disk</li>
+     *     <li>File is not opened for reading or writing</li>
+     *     <li>The underlying filesystem is slow to respond to lock requests on FileChannel</li>
+     * </ol>
+     * <br/>
+     * WHEN:
+     * <ol>
+     *     <li>Two reader threads attempt to open the file at the same time</li>
+     * </ol>
+     * <br/>
+     * THEN:
+     * <ol>
+     *     <li>One reader thread should "win" and be the first to open the file</li>
+     *     <li>The other reader thread should "join" that first thread's open file</li>
+     *     <li>No OverlappingFileLockException should be thrown</li>
+     * </ol>
+     * @throws Exception
+     */
+    /*@formatter:off*/
+    @BMRules( rules = {
+            // setup a rendezvous to control thread execution
+            @BMRule( name = "init rendezvous", targetClass = "FileTree",
+                     targetMethod = "<init>",
+                     targetLocation = "ENTRY",
+                     action = "createRendezvous(\"begin\", 2);" + "debug(\"<<<init rendezvous for begin.\")" ),
+            // sync up to reduce chances of missing the race condition for the opLock.lock() control.
+            @BMRule( name="sync FileTree.setOrJoin", targetClass = "FileTree",
+                     targetMethod = "setOrJoinFile",
+                     targetLocation = "ENTRY",
+                     action="debug(\"Rendezvous read operations.\"); "
+                             + "rendezvous(\"begin\"); "
+                             + "debug(\"Continue read operations.\");"),
+            // When we try to init a new JoinableFile for INPUT, simulate an IOException from somewhere deeper in the stack.
+            @BMRule( name = "new JoinableFile lock delay", targetClass = "JoinableFile", targetMethod = "<init>",
+                     targetLocation = "ENTRY",
+                     action = "debug(\"Delaying JoinableFile.init. Lock is: \" + $5); "
+                             + "Thread.sleep(500);"
+                             + "debug( \"Resuming lock operation.\" );" ) } )
+    /*@formatter:on*/
+    @BMUnitConfig( debug = true )
+    @Test
+    public void run()
+            throws Exception
+    {
+        byte[] bytes = new byte[1024*1024*2]; // let's get some serious data going.
+
+        Random rand = new Random();
+        rand.nextBytes( bytes );
+
+        final ExecutorService execs = Executors.newFixedThreadPool( 2 );
+        final File f = temp.newFile( "child.bin" );
+        FileUtils.writeByteArrayToFile( f, bytes );
+
+        final CountDownLatch latch = new CountDownLatch( 2 );
+        final JoinableFileManager manager = new JoinableFileManager();
+
+        manager.startReporting( 5000, 5000 );
+
+        for ( int i = 0; i < 2; i++ )
+        {
+            final int k = i;
+            execs.execute( reader( k, manager, f, latch, true ) );
+        }
+
+        latch.await();
+    }
+
+}

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteAndCloseBeforeFinishedTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteAndCloseBeforeFinishedTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteAndCloseBeforeFinishedTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteJustBeforeFinishedTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteJustBeforeFinishedTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteJustBeforeFinishedTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteTwiceWithDelayTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteTwiceWithDelayTest.java
@@ -73,7 +73,7 @@ public class JoinFileWriteTwiceWithDelayTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
@@ -60,7 +60,7 @@ public class JoinableFileTest
         String src = "This is a test";
         FileUtils.write( f, src );
 
-        final JoinableFile stream = new JoinableFile( f, newLockOwner( read ), false );
+        final JoinableFile stream = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
 
         System.out.println( "File length: " + f.length() );
 
@@ -82,9 +82,9 @@ public class JoinableFileTest
         assertReadOfExistingFileOfSize("11mb");
     }
 
-    private LockOwner newLockOwner( LockLevel level )
+    private LockOwner newLockOwner( String path, LockLevel level )
     {
-        return new LockOwner( Thread.currentThread().getName(), name.getMethodName(), level );
+        return new LockOwner( path, Thread.currentThread().getName(), name.getMethodName(), level );
     }
 
     private void assertReadOfExistingFileOfSize( String s )
@@ -102,7 +102,7 @@ public class JoinableFileTest
             IOUtils.write( src, out );
         }
 
-        final JoinableFile jf = new JoinableFile( f, newLockOwner( read ), false );
+        final JoinableFile jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
 
         try(InputStream stream = jf.joinStream())
         {
@@ -117,7 +117,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( read ), false );
+        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
 
@@ -130,7 +130,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( read ), false );
+        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
 
@@ -146,7 +146,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( read ), false );
+        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
         assertThat( jf.isJoinable(), equalTo( false ) );
@@ -160,7 +160,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( read ), false );
+        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
 
@@ -178,7 +178,7 @@ public class JoinableFileTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( tempFile, new LockOwner( threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );
@@ -203,14 +203,14 @@ public class JoinableFileTest
             throws Exception
     {
         File f = temp.newFile();
-        JoinableFile jf = new JoinableFile( f, newLockOwner( write ), true );
+        JoinableFile jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), write ), true );
         OutputStream stream = jf.getOutputStream();
 
         String longer = "This is a really really really long string";
         stream.write( longer.getBytes() );
         stream.close();
 
-        jf = new JoinableFile( f, newLockOwner( write ), true );
+        jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), write ), true );
         stream = jf.getOutputStream();
 
         String shorter = "This is a short string";
@@ -241,7 +241,7 @@ public class JoinableFileTest
         Logger logger = LoggerFactory.getLogger( getClass() );
         try
         {
-            jf = new JoinableFile( f, newLockOwner( read ), false );
+            jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
             s1 = jf.joinStream();
             s2 = jf.joinStream();
 
@@ -276,7 +276,7 @@ public class JoinableFileTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( tempFile, new LockOwner( threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/OpenInputStreamConcurrentReadersGetSameResultTest.java
+++ b/src/test/java/org/commonjava/util/partyline/OpenInputStreamConcurrentReadersGetSameResultTest.java
@@ -54,7 +54,7 @@ public class OpenInputStreamConcurrentReadersGetSameResultTest
             @BMRule( name = "second openInputStream", targetClass = "JoinableFileManager",
                      targetMethod = "openInputStream",
                      targetLocation = "ENTRY",
-                     condition = "$2==10",
+                     condition = "$2==100",
                      action = "debug(\">>>wait for service enter first openInputStream.\");"
                              + "waitFor(\"first openInputStream\");"
                              + "debug(\"<<<proceed with second openInputStream.\")" ),
@@ -98,7 +98,7 @@ public class OpenInputStreamConcurrentReadersGetSameResultTest
                             break;
                         case 1:
                             // note reporting timeout handle error
-                            s = manager.openInputStream( f, 10 );
+                            s = manager.openInputStream( f, 100 );
                             break;
                     }
                     returning.add( IOUtils.toString( s ) );
@@ -117,6 +117,8 @@ public class OpenInputStreamConcurrentReadersGetSameResultTest
         }
 
         latch.await();
+
+        assertThat( returning.size(), equalTo( 2 ) );
 
         assertThat( returning.get( 0 ), equalTo( str ) );
         assertThat( returning.get( 1 ), equalTo( str ) );

--- a/src/test/java/org/commonjava/util/partyline/UtilThreads.java
+++ b/src/test/java/org/commonjava/util/partyline/UtilThreads.java
@@ -74,7 +74,17 @@ public final class UtilThreads
         return reader( k, manager, f, masterLatch, null, null, null );
     }
 
-    public static Runnable reader( int k, JoinableFileManager manager, File f, CountDownLatch masterLatch, CountDownLatch readEndLatch, CountDownLatch readBeginLatch, CountDownLatch deleteEndLatch )
+    public static Runnable reader( int k, JoinableFileManager manager, File f, CountDownLatch masterLatch, boolean binaryContent )
+    {
+        return reader( k, manager, f, masterLatch, null, null, null, binaryContent );
+    }
+
+    public static Runnable reader( int k, JoinableFileManager manager, File f, CountDownLatch masterLatch, CountDownLatch readBeginLatch, CountDownLatch readEndLatch, CountDownLatch deleteEndLatch )
+    {
+        return reader( k, manager, f, masterLatch, readBeginLatch, readEndLatch, deleteEndLatch, true );
+    }
+
+    public static Runnable reader( int k, JoinableFileManager manager, File f, CountDownLatch masterLatch, CountDownLatch readBeginLatch, CountDownLatch readEndLatch, CountDownLatch deleteEndLatch, boolean binaryContent )
     {
         return () -> {
             Thread.currentThread().setName( "openInputStream-" + k );
@@ -110,7 +120,15 @@ public final class UtilThreads
 
             try (InputStream s = manager.openInputStream( f ))
             {
-                System.out.println( Thread.currentThread().getName() + ": " + IOUtils.toString( s ) );
+                if ( binaryContent )
+                {
+                    byte[] data = IOUtils.toByteArray( s );
+                    System.out.println( Thread.currentThread().getName() + ": Read " + data.length + " bytes." );
+                }
+                else
+                {
+                    System.out.println( Thread.currentThread().getName() + ": " + IOUtils.toString( s ) );
+                }
             }
             catch ( Exception e )
             {


### PR DESCRIPTION
Multiple callers trying to be the first to open a new joinable stream
were resulting in OverlappingFileLockException because the FileEntry
'file' field wasn't sufficiently protected.

New code adds extra synchronization and a tryLock() approach to locking
a re-entrant operation, with while-looping and a timeout to locking
attempts. This will hopefully guard against this problem without incurring
too much of a performance hit.

@ruhan1, @yma88, @ligangty Would 1-2 of you please look over my changes and make sure I didn't do anything stupid? I'm not sure how to arrange a test of this inside partyline...I'll try to set something up before merging this. It's possible this is the root cause of NOS-868, though I still don't have confirmation (haven't checked the reports yet).