### PR TITLE
reference counting per-ThreadContext in file locks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.commonjava.util</groupId>
   <artifactId>partyline</artifactId>
-  <version>1.9.4-SNAPSHOT</version>
+  <version>1.10.0-SNAPSHOT</version>
 
   <name>partyline</name>
   <inceptionYear>2015</inceptionYear>

--- a/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
+++ b/src/main/java/org/commonjava/util/partyline/FileOperationLock.java
@@ -43,8 +43,9 @@ final class FileOperationLock
         Logger logger = LoggerFactory.getLogger( getClass() );
         if ( logger.isTraceEnabled() )
         {
-            logger.trace( "Locking: {} for: {} from:\n\n{}\n\n", this, Thread.currentThread().getName(),
-                          join( Thread.currentThread().getStackTrace(), "\n  " ) );
+            logger.trace( "Locking: {} for: {}", this, Thread.currentThread().getName() );
+//            logger.trace( "Locking: {} for: {} from:\n\n{}\n\n", this, Thread.currentThread().getName(),
+//                          join( Thread.currentThread().getStackTrace(), "\n  " ) );
         }
 
         lock.lockInterruptibly();
@@ -60,7 +61,8 @@ final class FileOperationLock
             Logger logger = LoggerFactory.getLogger( getClass() );
             if ( logger.isTraceEnabled() )
             {
-                logger.trace( "Locking: {} (locked by: {}) from:\n\n{}\n\n", this, locker, join( Thread.currentThread().getStackTrace(), "\n  " ) );
+                logger.trace( "Locking: {} (locked by: {})", this, locker );
+//                logger.trace( "Locking: {} (locked by: {}) from:\n\n{}\n\n", this, locker, join( Thread.currentThread().getStackTrace(), "\n  " ) );
             }
 
             changed.signal();

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -399,7 +399,8 @@ public final class JoinableFile
                 }
                 else
                 {
-                    owner.unlock( originalThreadName );
+                    owner.unlock();
+//                    owner.unlock( originalThreadName );
                 }
 
                 return null;
@@ -423,16 +424,6 @@ public final class JoinableFile
     boolean isOpen()
     {
         return !closed || !inputs.isEmpty();
-    }
-
-    boolean isOwnedByCurrentThread()
-    {
-        return Thread.currentThread().getId() == owner.getThreadId();
-    }
-
-    boolean isOwnedBy( long ownerId )
-    {
-        return ownerId == owner.getThreadId();
     }
 
     private final class JoinableOutputStream

--- a/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
@@ -70,7 +70,7 @@ public class BinaryFileTest {
 
         File binaryFile = temp.newFile( "binary-file.bin" );
         ReentrantLock lock = new ReentrantLock();
-        JoinableFile jf = new JoinableFile( binaryFile, new LockOwner( binaryFile.getAbsolutePath(), Thread.currentThread().getName(),
+        JoinableFile jf = new JoinableFile( binaryFile, new LockOwner( binaryFile.getAbsolutePath(),
                                                                          name.getMethodName(), LockLevel.write ), true );
         OutputStream jos = jf.getOutputStream();
         InputStream actual = jf.joinStream();

--- a/src/test/java/org/commonjava/util/partyline/FileTreeTest.java
+++ b/src/test/java/org/commonjava/util/partyline/FileTreeTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 package org.commonjava.util.partyline;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -23,9 +24,14 @@ import org.junit.rules.TestName;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 /**
  * Created by jdcasey on 8/18/16.
@@ -40,16 +46,65 @@ public class FileTreeTest
     public TestName name = new TestName();
 
     @Test
+    public void lockDirThenLockFile()
+            throws IOException, InterruptedException
+    {
+        FileTree root = new FileTree();
+        String dirPath = "directory";
+        File child = createStructure( Paths.get( dirPath, "child.txt" ).toString(), true );
+        File dir = child.getParentFile();
+
+        boolean dirLocked = root.tryLock( dir, "lock directory", LockLevel.write, 2000, TimeUnit.MILLISECONDS );
+
+        assertThat( dirLocked, equalTo( true ) );
+
+        try (JoinableFile jf = root.setOrJoinFile( child, null, true, 2000, TimeUnit.MILLISECONDS,
+                                                   ( result ) -> result );
+             OutputStream out = jf.getOutputStream())
+        {
+            IOUtils.write( "This is a test", out );
+        }
+    }
+
+    @Test
+    public void lockDirThenLockTwoFiles()
+            throws IOException, InterruptedException
+    {
+        FileTree root = new FileTree();
+        String dirPath = "directory";
+        File child = createStructure( Paths.get( dirPath, "child.txt" ).toString(), true );
+        File child2 = createStructure( Paths.get( dirPath, "child2.txt" ).toString(), true );
+        File dir = child.getParentFile();
+
+        boolean dirLocked = root.tryLock( dir, "lock directory", LockLevel.write, 2000, TimeUnit.MILLISECONDS );
+
+        assertThat( dirLocked, equalTo( true ) );
+
+        try (JoinableFile jf = root.setOrJoinFile( child, null, true, 2000, TimeUnit.MILLISECONDS,
+                                                   ( result ) -> result );
+             JoinableFile jf2 = root.setOrJoinFile( child2, null, true, 2000, TimeUnit.MILLISECONDS,
+                                                    ( result ) -> result );
+             OutputStream out = jf.getOutputStream();
+             OutputStream out2 = jf2.getOutputStream();)
+        {
+            IOUtils.write( "This is a test", out2 );
+            out2.close();
+
+            IOUtils.write( "This is a test", out );
+        }
+    }
+
+    @Test
     public void addChildAndRenderTree()
             throws IOException, InterruptedException
     {
         FileTree root = new FileTree();
         File child = createStructure( "child.txt", true );
-        JoinableFile jf = root.setOrJoinFile( child, null, false, -1, TimeUnit.MILLISECONDS, (result)->result );
-//        JoinableFile jf = new JoinableFile( child, false );
-//        root.add( jf );
+        JoinableFile jf = root.setOrJoinFile( child, null, false, -1, TimeUnit.MILLISECONDS, ( result ) -> result );
+        //        JoinableFile jf = new JoinableFile( child, false );
+        //        root.add( jf );
 
-        System.out.println("File tree rendered as:\n"+ root.renderTree());
+        System.out.println( "File tree rendered as:\n" + root.renderTree() );
     }
 
     private File createStructure( String path, boolean writeTestFile )

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteAndCloseBeforeFinishedTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteAndCloseBeforeFinishedTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteAndCloseBeforeFinishedTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteJustBeforeFinishedTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteJustBeforeFinishedTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteJustBeforeFinishedTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteTwiceWithDelayTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteTwiceWithDelayTest.java
@@ -73,7 +73,7 @@ public class JoinFileWriteTwiceWithDelayTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
@@ -84,7 +84,7 @@ public class JoinableFileTest
 
     private LockOwner newLockOwner( String path, LockLevel level )
     {
-        return new LockOwner( path, Thread.currentThread().getName(), name.getMethodName(), level );
+        return new LockOwner( path, name.getMethodName(), level );
     }
 
     private void assertReadOfExistingFileOfSize( String s )
@@ -178,7 +178,7 @@ public class JoinableFileTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );
@@ -276,7 +276,7 @@ public class JoinableFileTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), threadName, name.getMethodName(), LockLevel.write ), true );
+                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/LockOwnerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/LockOwnerTest.java
@@ -1,0 +1,43 @@
+package org.commonjava.util.partyline;
+
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by jdcasey on 6/2/17.
+ */
+public class LockOwnerTest
+{
+
+    @Test
+    public void lockLevelSorting()
+    {
+        Optional<LockLevel> first = Stream.of( LockLevel.values() )
+                                          .sorted( ( o1, o2 ) -> new Integer( o2.ordinal() ).compareTo( o1.ordinal() ) )
+                                          .findFirst();
+
+        assertThat( first.get(), equalTo( LockLevel.delete ) );
+    }
+
+    @Test
+    public void lockClearAndLockAgainWithDifferentLevel()
+    {
+        LockOwner owner = new LockOwner( "/path/to/nowhere", "testing", LockLevel.write );
+
+        assertThat( owner.isLockedByCurrentThread(), equalTo( true ) );
+
+        boolean unlocked = owner.unlock();
+
+        assertThat( unlocked, equalTo( true ) );
+        assertThat( owner.isLockedByCurrentThread(), equalTo( false ) );
+
+        boolean locked = owner.lock( "relocking", LockLevel.delete );
+        assertThat( locked, equalTo( true ) );
+    }
+}

--- a/src/test/java/org/commonjava/util/partyline/ReadLockOnDerivativeDontPreventMainFileReadTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ReadLockOnDerivativeDontPreventMainFileReadTest.java
@@ -41,10 +41,10 @@ public class ReadLockOnDerivativeDontPreventMainFileReadTest
         extends AbstractBytemanTest
 {
     /**
-     * Test that verifies concurrent reading locks on different files will not effect each other's reading process, this setup an script of events for
-     * multiple files, where:
+     * Test that verifies concurrent reading locks on different files will not effect each other's reading process,
+     * this setup an script of events for multiple files, where:
      * <ol>
-     *     <li>Multiple reads happen simultaneously, read locks on distrinct files/li>
+     *     <li>Multiple reads happen simultaneously, read locks on distinct files/li>
      *     <li>Reading processes for different files are isolated</li>
      * </ol>
      * @throws Exception


### PR DESCRIPTION
We need to be able to lock a directory multiple times from a set of threads sharing the same ThreadContext, then write files inside that directory independently and unlock the directory without having to synchronize or coordinate the unlock call.

This change makes the owner name a value stored in ThreadContext instead of using Thread.getName() (which is arguably easier to change without understanding the implications). It also adds an AtomicInteger counter per owner to do reference counting, only removing the owner from the lock when the count reaches zero.

If an owner is removed, the dominant lock level for the file is updated to reflect the most aggressive lock that remains.