### PR TITLE
A fix for lock write more than twice in sequence in single thread

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/FileTree.java
+++ b/src/main/java/org/commonjava/util/partyline/FileTree.java
@@ -392,7 +392,7 @@ final class FileTree
                             throw new IOException( f + " does not exist. Cannot read-lock missing file!" );
                         }
 
-                        entry = new FileEntry( name, label, lockLevel, entry == null ? null : entry );
+                        entry = new FileEntry( name, label, lockLevel, entry );
                         logger.trace( "No lock; locking as: {} from: {}", lockLevel, label );
                         entryMap.put( name, entry );
                         try

--- a/src/main/java/org/commonjava/util/partyline/FileTree.java
+++ b/src/main/java/org/commonjava/util/partyline/FileTree.java
@@ -167,12 +167,8 @@ final class FileTree
                     if ( entry.lock.unlock() )
                     {
                         logger.trace( "Unlocked; clearing resources associated with lock" );
-                        if ( entry.file != null )
-                        {
-                            logger.trace( "{} Closing file...", ownerName );
-                            IOUtils.closeQuietly( entry.file );
-                            entry.file = null;
-                        }
+
+                        closeEntryFile( entry, ownerName );
 
                         if ( !unlockAssociatedEntries( entry, opLock ) )
                         {
@@ -269,12 +265,8 @@ final class FileTree
                     logger.trace( "Unlocking {}", f );
                     entry.lock.clearLocks();
                     logger.trace( "Unlocked; clearing resources associated with lock" );
-                    if ( entry.file != null )
-                    {
-                        logger.trace( "Closing file..." );
-                        IOUtils.closeQuietly( entry.file );
-                        entry.file = null;
-                    }
+
+                    closeEntryFile( entry, "" );
 
                     unlockAssociatedEntries( entry, opLock );
 
@@ -299,6 +291,16 @@ final class FileTree
         catch ( InterruptedException e )
         {
             logger.warn( "Interrupted while trying to unlock: " + f );
+        }
+    }
+
+    private void closeEntryFile( FileEntry entry, String extraTraceMsg )
+    {
+        if ( entry.file != null )
+        {
+            logger.trace( "{} Closing file...", extraTraceMsg == null ? "" : extraTraceMsg );
+            IOUtils.closeQuietly( entry.file );
+            entry.file = null;
         }
     }
 

--- a/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
@@ -34,6 +34,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.commonjava.util.partyline.LockLevel.read;
 import static org.commonjava.util.partyline.LockOwner.getLockReservationName;
 
 /**
@@ -382,7 +383,8 @@ public class JoinableFileManager
      */
     public boolean isWriteLocked( final File file )
     {
-        return locks.getLockLevel( file ) != null;
+        LockLevel lockLevel = locks.getLockLevel( file );
+        return lockLevel != null && lockLevel.ordinal() >= read.ordinal();
     }
 
     /**

--- a/src/main/java/org/commonjava/util/partyline/LockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/LockOwner.java
@@ -132,8 +132,6 @@ final class LockOwner
 
         int lockCount = lockOwnerInfo.locks.incrementAndGet();
 
-        Logger logger = LoggerFactory.getLogger( getClass() );
-
         logger.trace( "\n\n\n{}\n  Incremented lock count.\n  New count is: {} \n  Owner: {}\n  Ref: {}\n\n\n", path, lockCount, ownerName, label );
         return lockCount;
     }

--- a/src/main/java/org/commonjava/util/partyline/LockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/LockOwner.java
@@ -134,7 +134,7 @@ final class LockOwner
 
         Logger logger = LoggerFactory.getLogger( getClass() );
 
-        logger.trace( "\n\n\n{}\n  Incremented lock count to: {} \n  Owner: {}\n  Ref: {}\n\n\n", path, lockCount, ownerName, label );
+        logger.trace( "\n\n\n{}\n  Incremented lock count.\n  New count is: {} \n  Owner: {}\n  Ref: {}\n\n\n", path, lockCount, ownerName, label );
         return lockCount;
     }
 
@@ -149,7 +149,7 @@ final class LockOwner
         }
 
         int count = lockOwnerInfo.locks.decrementAndGet();
-        logger.trace( "Decremented lock count in: {} for owner: {}. New count is: {}\nLock Info:\n{}", this.path, ownerName, count, getLockInfo() );
+        logger.trace( "Decremented lock count.\n  Path: {}\n  for owner: {}\n  New count is: {}\nLock Info:\n{}", this.path, ownerName, count, getLockInfo() );
 
         if ( count < 1 )
         {

--- a/src/main/java/org/commonjava/util/partyline/LockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/LockOwner.java
@@ -79,12 +79,20 @@ final class LockOwner
             return true;
         }
 
+        LockOwnerInfo ownerInfo = locks.get( lockOwner );
+        if ( ownerInfo != null && ownerInfo.level == lockLevel )
+        {
+            increment(label, lockLevel);
+            return true;
+        }
+
         switch ( lockLevel )
         {
             case delete:
             case write:
             {
-                logger.trace( "[ABORT] Trying to lock at level: {} from owner: {}. Existing lock is: {}", lockLevel, lockOwner, this.dominantLockLevel );
+                logger.trace( "[ABORT] Trying to lock at level: {} from owner: {}. Existing lock is: {}", lockLevel,
+                              lockOwner, this.dominantLockLevel );
                 return false;
             }
             case read:
@@ -126,7 +134,7 @@ final class LockOwner
 
         Logger logger = LoggerFactory.getLogger( getClass() );
 
-        logger.trace( "{} Incremented lock count to: {} for owner: {} with ref: {}", this, lockCount, ownerName, label );
+        logger.trace( "\n\n\n{}\n  Incremented lock count to: {} \n  Owner: {}\n  Ref: {}\n\n\n", path, lockCount, ownerName, label );
         return lockCount;
     }
 

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
@@ -57,7 +57,7 @@ public class JoinableFileManagerTest
     private final JoinableFileManager mgr = new JoinableFileManager();
 
     @Test
-    @Ignore( "Deadlocks currently, needs to be fixed!" )
+//    @Ignore( "Deadlocks currently, needs to be fixed!" )
     public void lockAndUnlockTwiceInSequenceFromOneThread()
             throws IOException, InterruptedException
     {
@@ -70,7 +70,7 @@ public class JoinableFileManagerTest
     }
 
     @Test
-    @Ignore("A case that needs fix")
+//    @Ignore("A case that needs fix")
     public void lockTwiceForOneDir()
             throws IOException, InterruptedException
     {


### PR DESCRIPTION
@jdcasey this is a fix for the problem. It can pass that lockAndUnlockTwiceInSequenceFromOneThread case, but can not pass the lockTwiceForOneDir case which I added. In that case, I've added some lock state check for each lock and unlock operation. So I don't think this fix is completed and marked this pr as Not Ready.
Seems the lock state is not right, and I think the main cause is that the LIFO control of the thread lock count is still not very accurate yet. I'm a little confusing of the increment and decrement  for this lock count of the three lock level. In my fix, I just simple return true when the lock level is same with the dominant lock level of the owner in same thread(which I think it is the most suitable "re-entrant" state), but I'm not sure if the count should increase in this condition(I marked FIXME for it). I think it should increase, but when add that, there will be many cases failed. I'm thinking if some other decrease control if this increase is added, but not sorted it out yet. 