### PR TITLE
Fix directory lock handling when file locks are established/cleared

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/FileTree.java
+++ b/src/main/java/org/commonjava/util/partyline/FileTree.java
@@ -392,7 +392,7 @@ final class FileTree
                             throw new IOException( f + " does not exist. Cannot read-lock missing file!" );
                         }
 
-                        entry = new FileEntry( name, label, lockLevel, entry == null ? null : entry );
+                        entry = new FileEntry( name, label, lockLevel, entry );
                         logger.trace( "No lock; locking as: {} from: {}", lockLevel, label );
                         entryMap.put( name, entry );
                         try

--- a/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
@@ -34,6 +34,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.commonjava.util.partyline.LockLevel.read;
 import static org.commonjava.util.partyline.LockOwner.getLockReservationName;
 
 /**
@@ -382,7 +383,8 @@ public class JoinableFileManager
      */
     public boolean isWriteLocked( final File file )
     {
-        return locks.getLockLevel( file ) != null;
+        LockLevel lockLevel = locks.getLockLevel( file );
+        return lockLevel != null && lockLevel.ordinal() >= read.ordinal();
     }
 
     /**

--- a/src/main/java/org/commonjava/util/partyline/LockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/LockOwner.java
@@ -134,7 +134,7 @@ final class LockOwner
 
         Logger logger = LoggerFactory.getLogger( getClass() );
 
-        logger.trace( "\n\n\n{}\n  Incremented lock count to: {} \n  Owner: {}\n  Ref: {}\n\n\n", path, lockCount, ownerName, label );
+        logger.trace( "\n\n\n{}\n  Incremented lock count.\n  New count is: {} \n  Owner: {}\n  Ref: {}\n\n\n", path, lockCount, ownerName, label );
         return lockCount;
     }
 
@@ -149,7 +149,7 @@ final class LockOwner
         }
 
         int count = lockOwnerInfo.locks.decrementAndGet();
-        logger.trace( "Decremented lock count in: {} for owner: {}. New count is: {}\nLock Info:\n{}", this.path, ownerName, count, getLockInfo() );
+        logger.trace( "Decremented lock count.\n  Path: {}\n  for owner: {}\n  New count is: {}\nLock Info:\n{}", this.path, ownerName, count, getLockInfo() );
 
         if ( count < 1 )
         {

--- a/src/main/java/org/commonjava/util/partyline/LockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/LockOwner.java
@@ -79,12 +79,20 @@ final class LockOwner
             return true;
         }
 
+        LockOwnerInfo ownerInfo = locks.get( lockOwner );
+        if ( ownerInfo != null && ownerInfo.level == lockLevel )
+        {
+            increment(label, lockLevel);
+            return true;
+        }
+
         switch ( lockLevel )
         {
             case delete:
             case write:
             {
-                logger.trace( "[ABORT] Trying to lock at level: {} from owner: {}. Existing lock is: {}", lockLevel, lockOwner, this.dominantLockLevel );
+                logger.trace( "[ABORT] Trying to lock at level: {} from owner: {}. Existing lock is: {}", lockLevel,
+                              lockOwner, this.dominantLockLevel );
                 return false;
             }
             case read:
@@ -126,7 +134,7 @@ final class LockOwner
 
         Logger logger = LoggerFactory.getLogger( getClass() );
 
-        logger.trace( "{} Incremented lock count to: {} for owner: {} with ref: {}", this, lockCount, ownerName, label );
+        logger.trace( "\n\n\n{}\n  Incremented lock count to: {} \n  Owner: {}\n  Ref: {}\n\n\n", path, lockCount, ownerName, label );
         return lockCount;
     }
 

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
@@ -57,7 +57,7 @@ public class JoinableFileManagerTest
     private final JoinableFileManager mgr = new JoinableFileManager();
 
     @Test
-    @Ignore( "Deadlocks currently, needs to be fixed!" )
+//    @Ignore( "Deadlocks currently, needs to be fixed!" )
     public void lockAndUnlockTwiceInSequenceFromOneThread()
             throws IOException, InterruptedException
     {
@@ -70,7 +70,7 @@ public class JoinableFileManagerTest
     }
 
     @Test
-    @Ignore("A case that needs fix")
+//    @Ignore("A case that needs fix")
     public void lockTwiceForOneDir()
             throws IOException, InterruptedException
     {


### PR DESCRIPTION
This supercedes #69 by adding linked-list handling for FileEntries associated with all pre-existing directory locks in a file's directory structure when the file lock is established. It should solve all outstanding issues related to directory lock handling. See my latest commit in this PR for a more extensive description.