### PR TITLE
[1.9.x] Improve testing and ThreadContext sync, use ThreadContext finalizer for cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </scm>
   
   <properties>
-    <weftVersion>1.4</weftVersion>
+    <weftVersion>1.5-SNAPSHOT</weftVersion>
 
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </scm>
   
   <properties>
-    <weftVersion>1.5-SNAPSHOT</weftVersion>
+    <weftVersion>1.5</weftVersion>
 
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -64,7 +64,7 @@ import static org.commonjava.util.partyline.FileTree.DEFAULT_LOCK_TIMEOUT;
 public final class JoinableFile
         implements AutoCloseable, Closeable
 {
-    private static final int CHUNK_SIZE = 1024 * 8; // 8kb
+    private static final int CHUNK_SIZE = 1024 * 1024; // 1mb
 
     private final FileChannel channel;
 

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -551,9 +551,11 @@ public final class JoinableFile
 
         private boolean closed = false;
 
-        private int jointIdx;
+        private final int jointIdx;
 
-        private String originalThreadName;
+        private final String originalThreadName;
+
+        private final long ctorTime;
 
         /**
          * Map the content already written to disk for reading. If the flushed count exceeds MAX_BUFFER_SIZE, use the max instead.
@@ -564,6 +566,41 @@ public final class JoinableFile
             this.jointIdx = jointIdx;
             buf = channel.map( MapMode.READ_ONLY, 0, flushed > MAX_BUFFER_SIZE ? MAX_BUFFER_SIZE : flushed );
             this.originalThreadName = Thread.currentThread().getName();
+            this.ctorTime = System.nanoTime();
+        }
+
+        @Override
+        public boolean equals( final Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( !( o instanceof JoinInputStream ) )
+            {
+                return false;
+            }
+
+            final JoinInputStream that = (JoinInputStream) o;
+
+            if ( jointIdx != that.jointIdx )
+            {
+                return false;
+            }
+            if ( ctorTime != that.ctorTime )
+            {
+                return false;
+            }
+            return originalThreadName.equals( that.originalThreadName );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = jointIdx;
+            result = 31 * result + originalThreadName.hashCode();
+            result = 31 * result + (int) ( ctorTime ^ ( ctorTime >>> 32 ) );
+            return result;
         }
 
         /**

--- a/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
@@ -28,12 +28,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang.StringUtils.join;
 
 /**
  * File manager that attempts to manage read/write locks in the presence of output streams that will allow simultaneous access to read the content
@@ -47,6 +53,70 @@ public class JoinableFileManager
     public static final String PARTYLINE_OPEN_FILES = "partyline-open-files";
 
     public static final long DEFAULT_TIMEOUT = 1000;
+
+    private static final int MAX_CLEANUP_ITERATIONS = 3;
+    private static final long CLEANUP_ITERATION_WAIT = 1000;
+
+    /**
+     * Consumer of {@link ThreadContext} which clears the {@link #PARTYLINE_OPEN_FILES} map by closing all open files
+     * in that map, trying each one up to {@link #MAX_CLEANUP_ITERATIONS} times before giving up. Between cleanup
+     * iterations, it will pause {@link #CLEANUP_ITERATION_WAIT} milliseconds.
+     *
+     * @since 1.9.5
+     */
+    private static final Consumer<ThreadContext> FILE_CLEANUP = (tc)->{
+        Logger logger = LoggerFactory.getLogger( JoinableFileManager.class );
+
+        Map<String, WeakReference<Closeable>> open =
+                (Map<String, WeakReference<Closeable>>) tc.remove( PARTYLINE_OPEN_FILES );
+
+        if ( open != null )
+        {
+            int iterations = 0;
+            while( open.size() > 0 && iterations < MAX_CLEANUP_ITERATIONS )
+            {
+                for(String key: new HashSet<>( open.keySet()))
+                {
+                    WeakReference<Closeable> ref = open.remove( key );
+                    Closeable c = ref == null ? null : ref.get();
+
+                    if ( c != null )
+                    {
+                        try
+                        {
+                            c.close();
+                        }
+                        catch ( IOException ex )
+                        {
+                            logger.error( "Failed to close: " + key + ". Will retry.", ex );
+                            open.put( key, ref );
+                        }
+                    }
+                }
+
+                if ( !open.isEmpty() )
+                {
+                    try
+                    {
+                        Thread.sleep( CLEANUP_ITERATION_WAIT );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        logger.warn("JoinableFileManager cleanup routine interrupted! Aborting.");
+                        break;
+                    }
+                }
+
+                iterations++;
+            }
+
+            if ( !open.isEmpty() )
+            {
+                logger.error( "JoinableFileManager cleanup routine giving up! {} files remain unclosed:\n\n  - {}\n\n",
+                              open.size(), join( open.keySet(), "\n  - " ) );
+            }
+        }
+    };
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -72,35 +142,12 @@ public class JoinableFileManager
      * a separate thread for reading / writing, while the original thread does something else. However, when all threads
      * related to a particular call or user request are finished, we need to ensure that request gets cleaned up. This
      * method enables that.
+     *
+     * @see #FILE_CLEANUP
      */
     public void cleanupCurrentThread()
     {
-        ThreadContext context = ThreadContext.getContext( false );
-        if ( context == null )
-        {
-            return;
-        }
-
-        Map<String, WeakReference<Closeable>> open = (Map<String, WeakReference<Closeable>>) context.remove( PARTYLINE_OPEN_FILES );
-        if ( open != null )
-        {
-            open.entrySet().parallelStream().forEach( ( e ) -> {
-                String name = e.getKey();
-                Closeable c = e.getValue().get();
-                if ( c != null )
-                {
-                    try
-                    {
-                        c.close();
-                    }
-                    catch ( IOException ex )
-                    {
-                        logger.error( "Failed to close: " + name + ". Re-adding to thread context.", ex );
-                        addToContext( name, c );
-                    }
-                }
-            } );
-        }
+        // NOP, now handled by ThreadContext finalizer.
     }
 
     /**
@@ -303,13 +350,18 @@ public class JoinableFileManager
         ThreadContext threadContext = ThreadContext.getContext( false );
         if ( closeable != null && threadContext != null )
         {
-            Map<String, WeakReference<Closeable>> open = (Map<String, WeakReference<Closeable>>) threadContext.get( PARTYLINE_OPEN_FILES );
-            if ( open == null )
+            synchronized ( threadContext )
             {
-                open = new WeakHashMap<>();
-                threadContext.put( PARTYLINE_OPEN_FILES, open );
+                Map<String, WeakReference<Closeable>> open = (Map<String, WeakReference<Closeable>>) threadContext.get( PARTYLINE_OPEN_FILES );
+                if ( open == null )
+                {
+                    open = new WeakHashMap<>();
+                    threadContext.put( PARTYLINE_OPEN_FILES, open );
+                }
+                open.put( name, new WeakReference<>( closeable ) );
+
+                threadContext.registerFinalizer( FILE_CLEANUP );
             }
-            open.put( name, new WeakReference<>( closeable ) );
         }
     }
 

--- a/src/test/java/org/commonjava/util/partyline/ClearThreadContextClosesMappedOpenStreamsTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ClearThreadContextClosesMappedOpenStreamsTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-public class CleanupThreadContextHandleTest
+public class ClearThreadContextClosesMappedOpenStreamsTest
                 extends AbstractJointedIOTest
 {
 
@@ -49,7 +49,7 @@ public class CleanupThreadContextHandleTest
                             (Map<String, WeakReference<Closeable>>) context.get( PARTYLINE_OPEN_FILES );
             assertThat( open1.size(), equalTo( 1 ) );
 
-            manager.cleanupCurrentThread();
+            ThreadContext.clearContext();
             Map<String, WeakReference<Closeable>> open2 =
                             (Map<String, WeakReference<Closeable>>) context.get( PARTYLINE_OPEN_FILES );
             assertThat( open2, equalTo( null ) );

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
@@ -318,7 +318,7 @@ public class JoinableFileManagerTest
     }
 
     @Test
-    public void openInputStream_cleanupCurrentThread_openOutputStream()
+    public void openInputStream_clearThreadContext_openOutputStream()
         throws Exception
     {
         ThreadContext.getContext( true );
@@ -326,7 +326,9 @@ public class JoinableFileManagerTest
         final File f = temp.newFile("test.txt");
         FileUtils.write( f, "This is first pass" );
         mgr.openInputStream( f );
-        mgr.cleanupCurrentThread();
+//        mgr.cleanupCurrentThread();
+        ThreadContext.clearContext();
+        ThreadContext.getContext( true );
         OutputStream outputStream = mgr.openOutputStream( f );
 
         outputStream.close();

--- a/src/test/java/org/commonjava/util/partyline/ManyReadersWithPreExistingWriterTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ManyReadersWithPreExistingWriterTest.java
@@ -1,0 +1,239 @@
+package org.commonjava.util.partyline;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.cdi.util.weft.ContextSensitiveExecutorService;
+import org.commonjava.cdi.util.weft.ThreadContext;
+import org.commonjava.util.partyline.fixture.ThreadDumper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by jdcasey on 11/14/17.
+ */
+public class ManyReadersWithPreExistingWriterTest
+        extends AbstractJointedIOTest
+{
+    private static final int THREADS = 100;
+
+    private static final long WAIT = 0;
+
+    private static final int ITERATIONS = 10;
+
+    private ExecutorService executor = new ContextSensitiveExecutorService( Executors.newCachedThreadPool() );
+
+    private final JoinableFileManager mgr = new JoinableFileManager();
+
+    private String content;
+
+    private File file;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Rule
+    public TestRule timeout = ThreadDumper.timeoutRule( 2, TimeUnit.MINUTES );
+
+    @Before
+    public void setup()
+            throws IOException
+    {
+        file = temp.newFile( "testfile.txt" );
+
+        mgr.startReporting();
+
+        StringBuilder contentBuilder = new StringBuilder();
+        for ( int i = 0; i < COUNT; i++ )
+        {
+            contentBuilder.append( System.currentTimeMillis() ).append( "\n" );
+        }
+
+        content = contentBuilder.toString();
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final List<Long> timings = new ArrayList<>();
+        for ( int i = 0; i < ITERATIONS; i++ )
+        {
+            long start = System.currentTimeMillis();
+            executeTestIteration();
+            long end = System.currentTimeMillis();
+            timings.add( end - start );
+        }
+
+        long total = 0;
+        for ( Long time : timings )
+        {
+            total += time;
+        }
+
+        logger.info( "Average: {}ms (per-thread: {}ms)", ( total / timings.size() ),
+                     ( total / ( timings.size() * THREADS ) ) );
+    }
+
+    private void executeTestIteration()
+            throws Exception
+    {
+        ThreadContext.getContext( true );
+
+        ExecutorCompletionService<String> completionService = new ExecutorCompletionService<String>( executor );
+
+        final AtomicBoolean readFlag = new AtomicBoolean( false );
+        final AtomicBoolean writeFlag = new AtomicBoolean( false );
+
+        completionService.submit( writer( writeFlag, readFlag ) );
+        for ( int i = 0; i < THREADS; i++ )
+        {
+            completionService.submit( reader( readFlag ) );
+        }
+
+        writeFlag.set( true );
+
+        for ( int i=0; i<(THREADS+1); i++)
+        {
+            String error = completionService.take().get();
+            if ( error != null )
+            {
+                logger.info( error );
+                fail( "thread failed.");
+            }
+            assertThat( error, nullValue() );
+        }
+
+        ThreadContext.clearContext();
+    }
+
+    private Callable<String> reader( final AtomicBoolean readFlag )
+    {
+        return () ->
+        {
+            String error = null;
+            synchronized ( this )
+            {
+                while ( !readFlag.get() )
+                {
+                    try
+                    {
+//                            logger.info(
+//                                    "Waiting for readMutex notification before reading test file..." );
+                        wait( 10 );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        e.printStackTrace();
+                        error = "Failed to wait for readMutex";
+                    }
+                }
+            }
+
+            if ( error != null )
+            {
+                return error;
+            }
+
+            logger.info( "Reading test file" );
+            try (InputStream stream = mgr.openInputStream( file ))
+            {
+                String result = IOUtils.toString( stream );
+                if ( !content.equals( result ) )
+                {
+                    error = String.format( "Content mismatch!\nExpected:\n\n%s\n\nActual:\n\n%s", content, result );
+                }
+            }
+            catch ( IOException | InterruptedException e )
+            {
+                e.printStackTrace();
+                error = "Failed to write test file.";
+            }
+
+            return error;
+        };
+    }
+
+    private Callable<String> writer( final AtomicBoolean writeFlag, final AtomicBoolean readFlag )
+    {
+        return () ->
+        {
+            String error = null;
+            synchronized ( this )
+            {
+                while ( !writeFlag.get() )
+                {
+                    try
+                    {
+                        wait(10);
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        e.printStackTrace();
+                        error = "Failed to wait for writeMutex";
+                    }
+                }
+            }
+
+            if ( error != null )
+            {
+                return error;
+            }
+
+            logger.info( "Writing test file" );
+            byte[] data = content.getBytes();
+            try (OutputStream stream = mgr.openOutputStream( file ))
+            {
+                for ( int i = 0; i < data.length; i++ )
+                {
+                    //                    logger.info( "write: {}", i );
+                    stream.write( data[i] );
+                    if ( WAIT > 0 )
+                    {
+                        synchronized ( this )
+                        {
+                            wait( WAIT );
+                        }
+                    }
+
+                    // wait for there to be something in the buffer.
+                    if ( i < 1 )
+                    {
+                        logger.info( "Notifying readMutex" );
+                        readFlag.set( true );
+                    }
+                }
+
+                logger.info( "Write complete. Closing output stream." );
+            }
+            catch ( IOException | InterruptedException e )
+            {
+                e.printStackTrace();
+                error = "Failed to write test file";
+            }
+
+            return error;
+        };
+    }
+}

--- a/src/test/java/org/commonjava/util/partyline/ManyReadersWithPreExistingWriterTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ManyReadersWithPreExistingWriterTest.java
@@ -37,11 +37,11 @@ import static org.junit.Assert.fail;
 public class ManyReadersWithPreExistingWriterTest
         extends AbstractJointedIOTest
 {
-    private static final int THREADS = 100;
+    private static final int THREADS = 30;
 
     private static final long WAIT = 0;
 
-    private static final int ITERATIONS = 10;
+    private static final int ITERATIONS = 2;
 
     private ExecutorService executor = new ContextSensitiveExecutorService( Executors.newCachedThreadPool() );
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -9,6 +9,7 @@
   </appender>
 
   <logger name="org.commonjava.util.partyline" level="TRACE" />
+  <logger name="org.commonjava.util.cdi.weft" level="TRACE" />
 
   <root level="TRACE">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Using ThreadContext finalizer (new) in place of old cleanupCurrentThread() call to cleanup the map of open streams in the ThreadContext. This is to prevent the end of a user request thread from undercutting "child" threads (threads doing async event processing resulting from the user request) by closing streams they are still using. The finalizer approach will watch for threads referencing ThreadContext and run the finalizer logic when the count hits zero...so the last thread / runnable that finishes will close the map of open streams. **NOTE:** This isn't a problem we see often, but it shows up periodically when the server is under extreme load. It is unlikely to cause direct disruption to the user, but may cause problems for later users if the async post-processing doesn't work correctly.

Also, I improved synchronization around the way JoinableFileManager initializes or clears the open streams map in the ThreadContext, to avoid race conditions related to that (suspected, not directly evident).

Finally, I added a stress test for one writer, many readers to see if I could trigger a deadlock. It can take time to clear when there are many, many readers, but it always clears (so far).