### PR TITLE
increase transfer buffer for JoinableFile to 1MB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </scm>
   
   <properties>
-    <weftVersion>1.5-SNAPSHOT</weftVersion>
+    <weftVersion>1.5</weftVersion>
 
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -64,7 +64,7 @@ import static org.commonjava.util.partyline.FileTree.DEFAULT_LOCK_TIMEOUT;
 public final class JoinableFile
         implements AutoCloseable, Closeable
 {
-    private static final int CHUNK_SIZE = 1024 * 8; // 8kb
+    private static final int CHUNK_SIZE = 1024 * 1024; // 1mb
 
     private final FileChannel channel;
 


### PR DESCRIPTION
This drastically increases performance for large files by reducing the amount of thread signalling (guessing, but results are real).

Also bumped the weft version to the 1.5 release.

Finally, I changed the performance test to display the actual ratios of performance, not the performance ratio limit.