### PR TITLE
Remove error prone WeakHashMap in JoinableFileManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </scm>
   
   <properties>
-    <weftVersion>1.5</weftVersion>
+    <weftVersion>1.6-SNAPSHOT</weftVersion>
 
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>

--- a/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
@@ -28,15 +28,12 @@ import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.StringUtils.join;
 
@@ -357,8 +354,8 @@ public class JoinableFileManager
                 Map<String, WeakReference<Closeable>> open = (Map<String, WeakReference<Closeable>>) threadContext.get( PARTYLINE_OPEN_FILES );
                 if ( open == null )
                 {
-                    open = new WeakHashMap<>();
-                    threadContext.put( PARTYLINE_OPEN_FILES, open );
+                    open = new HashMap<>();
+                    threadContext.put( PARTYLINE_OPEN_FILES, open ); // FILE_CLEANUP will remove it
                 }
                 open.put( name, new WeakReference<>( closeable ) );
 

--- a/src/test/java/org/commonjava/util/partyline/ReadLockOnDerivativeDontPreventMainFileReadTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ReadLockOnDerivativeDontPreventMainFileReadTest.java
@@ -100,12 +100,12 @@ public class ReadLockOnDerivativeDontPreventMainFileReadTest
                 switch ( k )
                 {
                     case 0:
-                        file = dFile;
-                        name = derivative;
-                        break;
-                    case 1:
                         file = mFile;
                         name = main;
+                        break;
+                    case 1:
+                        file = dFile;
+                        name = derivative;
                         break;
                 }
                 Thread.currentThread().setName( name );
@@ -124,6 +124,7 @@ public class ReadLockOnDerivativeDontPreventMainFileReadTest
                     latch.countDown();
                 }
             } );
+            Thread.sleep( 1000 ); // make the fragile BMRule to always work
         }
 
         latch.await();


### PR DESCRIPTION
The prev "open = new WeakHashMap<>()" sounds like a bug for me. This could cause stream leak AIUI. Since the FILE_CLEANUP will remove it once the context is cleared, we can just use a normal map for it. 

P.S. fix a test problem. That one sometimes passes sometimes fails. I fixed it. 