### PR TITLE
Enlarge the synchronize scope in JoinableFileOutputStream.flush

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -439,17 +439,20 @@ public final class JoinableFile
         public void write( final int b )
                 throws IOException
         {
-            if ( closed )
+            synchronized ( JoinableFile.this )
             {
-                throw new IOException( "Cannot write to closed stream!" );
-            }
+                if ( closed )
+                {
+                    throw new IOException( "Cannot write to closed stream!" );
+                }
 
-            if ( buf.position() == buf.capacity() )
-            {
-                flush();
-            }
+                if ( buf.position() == buf.capacity() )
+                {
+                    flush();
+                }
 
-            buf.put( (byte) ( b & 0xff ) );
+                buf.put( (byte) ( b & 0xff ) );
+            }
         }
 
         /**


### PR DESCRIPTION
   Currently there is some unknown problem causes the fileChannel
writing some ex-limit or empty content in buffer, which caused
IllegalArgumentException in Buffer.position(position) in this flush
method. Some suspicious point is the unknown race condition here, so
enlarge the synchronize scope which also inclueds the channel.write.