### PR TITLE
take out use of channel.size() and just track file length via flushed field

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -69,7 +69,7 @@ public final class JoinableFile
 
     private final Map<Integer, JoinInputStream> inputs = new HashMap<>();
 
-    private long flushed = 0;
+    private volatile long flushed = 0;
 
     private final String path;
 
@@ -645,11 +645,7 @@ public final class JoinableFile
             {
                 //                logger.trace( "Joint: {} READ: filling buffer from {} to {} bytes", jointIdx, read, (flushed-read) );
                 // map more content from the file, reading past our read-bytes count up to the number of flushed bytes from the parent stream
-                long end = flushed > MAX_BUFFER_SIZE ? MAX_BUFFER_SIZE : flushed - read;
-                if ( (read + end ) > channel.size() )
-                {
-                    end = channel.size() - read;
-                }
+                long end = flushed - read > MAX_BUFFER_SIZE ? MAX_BUFFER_SIZE : flushed - read;
 
                 Logger logger = LoggerFactory.getLogger( getClass() );
                 logger.trace( "Buffering {} - {} (size is: {})\n", read, read+end, channel.size() );

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -478,7 +478,7 @@ public final class JoinableFile
                     {
                         count += channel.write( buf );
                     }
-                    channel.force( false );
+                    channel.force( true );
                 }
                 else
                 {

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -648,7 +648,7 @@ public final class JoinableFile
                 long end = flushed - read > MAX_BUFFER_SIZE ? MAX_BUFFER_SIZE : flushed - read;
 
                 Logger logger = LoggerFactory.getLogger( getClass() );
-                logger.trace( "Buffering {} - {} (size is: {})\n", read, read+end, channel.size() );
+                logger.trace( "Buffering {} - {} (size is: {})\n", read, read+end, flushed );
 
                 buf = channel.map( MapMode.READ_ONLY, read,
                                    end );


### PR DESCRIPTION
* Take out use of channel.size() and just track file length via flushed field
* Also, fix end-boundary setting for read buffer to account for # read bytes.
* Finally, and maybe most importantly, make the flushed field volatile so all threads will
get updated values when the writer flushes data out.