### PR TITLE
turn off stream finalizer registration

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
@@ -344,24 +344,25 @@ public class JoinableFileManager
      */
     private void addToContext( String name, Closeable closeable )
     {
-        logger.debug( "Adding {} to closeable set in ThreadContext", name );
-
-        ThreadContext threadContext = ThreadContext.getContext( false );
-        if ( closeable != null && threadContext != null )
-        {
-            synchronized ( threadContext )
-            {
-                Map<String, WeakReference<Closeable>> open = (Map<String, WeakReference<Closeable>>) threadContext.get( PARTYLINE_OPEN_FILES );
-                if ( open == null )
-                {
-                    open = new HashMap<>();
-                    threadContext.put( PARTYLINE_OPEN_FILES, open ); // FILE_CLEANUP will remove it
-                }
-                open.put( name, new WeakReference<>( closeable ) );
-
-                threadContext.registerFinalizer( FILE_CLEANUP );
-            }
-        }
+        // [jdcasey]: Disabling this to avoid stream-closing problems associated with threaded Indy execution.
+//        logger.debug( "Adding {} to closeable set in ThreadContext", name );
+//
+//        ThreadContext threadContext = ThreadContext.getContext( false );
+//        if ( closeable != null && threadContext != null )
+//        {
+//            synchronized ( threadContext )
+//            {
+//                Map<String, WeakReference<Closeable>> open = (Map<String, WeakReference<Closeable>>) threadContext.get( PARTYLINE_OPEN_FILES );
+//                if ( open == null )
+//                {
+//                    open = new HashMap<>();
+//                    threadContext.put( PARTYLINE_OPEN_FILES, open ); // FILE_CLEANUP will remove it
+//                }
+//                open.put( name, new WeakReference<>( closeable ) );
+//
+//                threadContext.registerFinalizer( FILE_CLEANUP );
+//            }
+//        }
     }
 
     /**

--- a/src/test/java/org/commonjava/util/partyline/CleanupThreadIOExceptionHandleTest.java
+++ b/src/test/java/org/commonjava/util/partyline/CleanupThreadIOExceptionHandleTest.java
@@ -20,6 +20,7 @@ import org.commonjava.cdi.util.weft.ThreadContext;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -49,6 +50,7 @@ public class CleanupThreadIOExceptionHandleTest
     @BMRule( name = "cleanupThreadIOExceptionHandleTest", targetClass = "java.io.OutputStream", targetMethod = "close", targetLocation = "ENTRY", action = "throw new java.io.IOException()" )
     @Test
     @BMUnitConfig( debug = true )
+    @Ignore
     public void run() throws Exception
     {
         final JoinableFileManager manager = new JoinableFileManager();

--- a/src/test/java/org/commonjava/util/partyline/ClearThreadContextClosesMappedOpenStreamsTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ClearThreadContextClosesMappedOpenStreamsTest.java
@@ -17,6 +17,7 @@ package org.commonjava.util.partyline;
 
 import org.apache.commons.io.FileUtils;
 import org.commonjava.cdi.util.weft.ThreadContext;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Closeable;
@@ -35,6 +36,7 @@ public class ClearThreadContextClosesMappedOpenStreamsTest
 {
 
     @Test
+    @Ignore
     public void run() throws Exception
     {
         final JoinableFileManager manager = new JoinableFileManager();

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
@@ -537,6 +537,7 @@ public class JoinableFileManagerTest
     }
 
     @Test
+    @Ignore
     public void openInputStream_clearThreadContext_openOutputStream()
         throws Exception
     {


### PR DESCRIPTION
We're having problems in Indy where certain streams are opened inside a ThreadContext
and get registered, then are handed off to threads that are outside the context for
streaming back to the user (and there's another more mysterious case happening when
trying to merge metadata files in Indy).

If we have good coding discipline inside Indy, we shouldn't need this finalizer to
come along behind and clean up the streams...they should already be cleaned up as we go.

This change simply disables registration of streams in the ThreadContext finalizer.