### PR TITLE
Improve open-file ownership reporting, and reduce synchronization overhead

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
@@ -223,7 +223,7 @@ public class JoinableFileManager
                 owner.append( " (JoinableFile locked as READ)" );
             }
 
-            active.put( new File( jf.getPath() ), owner );
+            active.put( new File( jf.getPath() ), jf.reportOwnership() );
         } );
 
         return active;


### PR DESCRIPTION
There were some really large synchronized blocks in JoinableFile, and
some misuse of the closed boolean, which was NOT marked as volatile. I
theorize that the overuse of synchronized (and repeated setting of the
closed flag) is related to the missing volatile keyword. I've reduced
these synchronized blocks accordingly to test it.

Also, I've included better reporting for exactly which threads are maintaining
open streams on a JoinableFile, so we can see this in the open files report
that hits the logs every 10 seconds.