### PR TITLE
use thread+action labels for locks to make open-file reporting better

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </scm>
   
   <properties>
-    <weftVersion>1.6-SNAPSHOT</weftVersion>
+    <weftVersion>1.6</weftVersion>
 
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.commonjava.util</groupId>
   <artifactId>partyline</artifactId>
-  <version>1.13</version>
+  <version>1.14-SNAPSHOT</version>
 
   <name>partyline</name>
   <inceptionYear>2015</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/Commonjava/partyline.git</connection>
     <developerConnection>scm:git:git@github.com:Commonjava/partyline.git</developerConnection>
     <url>https://github.com/Commonjava/partyline</url>
-    <tag>partyline-1.13</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.commonjava.util</groupId>
   <artifactId>partyline</artifactId>
-  <version>1.13-SNAPSHOT</version>
+  <version>1.13</version>
 
   <name>partyline</name>
   <inceptionYear>2015</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/Commonjava/partyline.git</connection>
     <developerConnection>scm:git:git@github.com:Commonjava/partyline.git</developerConnection>
     <url>https://github.com/Commonjava/partyline</url>
-    <tag>HEAD</tag>
+    <tag>partyline-1.13</tag>
   </scm>
   
   <properties>

--- a/src/main/java/org/commonjava/util/partyline/JoinableFile.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFile.java
@@ -279,7 +279,7 @@ public final class JoinableFile
                 logger.trace( "joint count is: {}.", inputs.size() );
                 if ( channel == null || inputs.isEmpty() )
                 {
-                    logger.trace( "Joints closed, really closing..." );
+                    logger.trace( "Joints closed, and output is closed...really closing." );
                     reallyClose();
                     owner.clearLocks();
                 }
@@ -392,13 +392,14 @@ public final class JoinableFile
                 {
                     if ( output == null || output.isClosed() )
                     {
+                        logger.trace( "All input joint closed, and output is missing or closed. Really closing." );
                         closed = true;
                         reallyClose();
                     }
                 }
                 else
                 {
-                    owner.unlock();
+                    owner.unlock( labelFor( false, originalThreadName ) );
 //                    owner.unlock( originalThreadName );
                 }
 
@@ -443,6 +444,11 @@ public final class JoinableFile
         inputs.forEach( (hashCode, instance)-> sb.append( "\n\t- " ).append( instance.reportWithOwner() ) );
 
         return sb.toString();
+    }
+
+    public static String labelFor( final boolean doOutput, String threadName )
+    {
+        return (doOutput ? "WRITE via " : "READ via ") + threadName;
     }
 
     private final class JoinableOutputStream

--- a/src/test/java/org/commonjava/util/partyline/LockOwnerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/LockOwnerTest.java
@@ -43,11 +43,12 @@ public class LockOwnerTest
     @Test
     public void lockClearAndLockAgainWithDifferentLevel()
     {
-        LockOwner owner = new LockOwner( "/path/to/nowhere", "testing", LockLevel.write );
+        String label = "testing";
+        LockOwner owner = new LockOwner( "/path/to/nowhere", label, LockLevel.write );
 
         assertThat( owner.isLockedByCurrentThread(), equalTo( true ) );
 
-        boolean unlocked = owner.unlock();
+        boolean unlocked = owner.unlock( label );
 
         assertThat( unlocked, equalTo( true ) );
         assertThat( owner.isLockedByCurrentThread(), equalTo( false ) );


### PR DESCRIPTION
We need to review this and test it in the context of an actual Indy deployment before releasing. I'm holding it back from the partyline release I'm doing today for that reason.

The intention here is to make it clearer why a stream was locked. This change may not be quite enough to answer that question, but keeping a simple lock counter (what this commit changes away from) loses a lot of information about who retains locks, and for what purpose.