### PR TITLE
FileTree lock removal fix, and fix for unused StringBuilder in reporting active locks

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/FileTree.java
+++ b/src/main/java/org/commonjava/util/partyline/FileTree.java
@@ -176,7 +176,10 @@ final class FileTree
                             return false;
                         }
 
-                        entryMap.remove( entry.name );
+                        if ( !entry.lock.isLocked() )
+                        {
+                            entryMap.remove( entry.name );
+                        }
 
                         opLock.signal();
                         logger.trace( "Unlock succeeded." );

--- a/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
+++ b/src/main/java/org/commonjava/util/partyline/JoinableFileManager.java
@@ -202,31 +202,7 @@ public class JoinableFileManager
     {
         final Map<File, CharSequence> active = new HashMap<>();
 
-        locks.forAll( ( jf ) -> {
-            final StringBuilder owner = new StringBuilder();
-
-            if ( jf.isWriteLocked() )
-            {
-                owner.append( " (JoinableFile locked as WRITE)" );
-            }
-            else
-            {
-                owner.append( " (JoinableFile locked as READ)" );
-            }
-
-            final LockOwner ref = jf.getLockOwner();
-
-            if ( ref == null )
-            {
-                owner.append( "\nUNKNOWN OWNER; REF IS NULL." );
-            }
-            else
-            {
-                owner.append('\n').append( ref.getLockInfo() );
-            }
-
-            active.put( new File( jf.getPath() ), jf.reportOwnership() );
-        } );
+        locks.forAll( ( jf ) -> active.put( new File( jf.getPath() ), jf.reportOwnership() ));
 
         return active;
     }


### PR DESCRIPTION
Regarding the FileTree lock fix:

Previously, when we called JoinableFileManager.unlock(File), we would only check the lock count for the current ThreadContext. If that lock count decremented to zero, we would blindly remove the lock from the FileTree used to track locked files across threads. This could result in two threads from different user requests accessing the same file and colliding (writing while another deletes, for instance...or two writing at once).

This fix will check if any locks from _any_ threads remain on the file before removing it from the FileTree.