### PR TITLE
Remove sync on FileTree getNearestLockingEntry

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/Partyline.java
+++ b/src/main/java/org/commonjava/util/partyline/Partyline.java
@@ -43,6 +43,7 @@ import static org.apache.commons.lang.StringUtils.join;
 
 import static org.commonjava.util.partyline.lock.LockLevel.read;
 import static org.commonjava.util.partyline.lock.local.LocalLockOwner.getLockReservationName;
+import static org.commonjava.util.partyline.util.FileTreeUtils.forAll;
 
 /**
  * File manager that attempts to manage read/write locks in the presence of output streams that will allow simultaneous access to read the content
@@ -212,7 +213,7 @@ public class Partyline
     {
         final Map<File, CharSequence> active = new HashMap<>();
 
-        locks.forAll( ( jf ) -> active.put( new File( jf.getPath() ), jf.reportOwnership() ));
+        forAll( locks.getUnmodifiableEntryMap(), ( jf ) -> active.put( new File( jf.getPath() ), jf.reportOwnership() ));
 
         return active;
     }

--- a/src/main/java/org/commonjava/util/partyline/util/FileTreeUtils.java
+++ b/src/main/java/org/commonjava/util/partyline/util/FileTreeUtils.java
@@ -1,0 +1,124 @@
+package org.commonjava.util.partyline.util;
+
+import org.commonjava.util.partyline.FileTree;
+import org.commonjava.util.partyline.spi.JoinableFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class FileTreeUtils
+{
+    private static final Logger logger = LoggerFactory.getLogger( FileTreeUtils.class );
+
+    /**
+     * When trying to lock a file, we first must ensure that no directory further up the hierarchy is already locked with
+     * a more restrictive lock. If we're trying to lock a directory, we also must ensure that no child directory/file
+     * is locked with a more restrictive lock. This method checks for those cases, and returns the {@link FileTree.FileEntry}
+     * from the ancestry or descendent files/directories that is already locked.
+     *
+     * This should prevent us from deleting a directory when a child file within that directory structure is being read
+     * or written. Likewise, it should prevent us from reading or writing a file in a directory already locked for
+     * deletion.
+     *
+     * @param file The file whose context directories / files should be checked for locks
+     * @return The nearest {@link FileTree.FileEntry}, corresponding to a locked file. Parent directories returned before children.
+     */
+    public static FileTree.FileEntry getNearestLockingEntry( Map<String, FileTree.FileEntry> entryMap, File file )
+    {
+        FileTree.FileEntry entry;
+
+        // search self and ancestors...
+        File f = file;
+        do
+        {
+            entry = entryMap.get( f.getAbsolutePath() );
+            if ( entry != null )
+            {
+                logger.trace( "Locked by: {}", entry.getLockOwner().getLockInfo() );
+                return entry;
+            }
+            else
+            {
+                logger.trace( "No lock found for: {}", f );
+            }
+
+            f = f.getParentFile();
+        }
+        while ( f != null );
+
+        // search for children...
+        if ( file.isDirectory() )
+        {
+            final String fp = file.getAbsolutePath() + File.separator;
+            Optional<String> result =
+                            entryMap.keySet().stream().filter( ( path ) -> path.startsWith( fp ) ).findFirst();
+            if ( result.isPresent() )
+            {
+                logger.trace( "Child: {} is locked; returning child as locking entry", result.get() );
+                return entryMap.get( result.get() );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Iterate all {@link FileTree.FileEntry instances} to extract information about active locks.
+     *
+     * @param fileConsumer The operation to extract information from a single active file.
+     */
+    public static void forAll( Map<String, FileTree.FileEntry> entryMap, Consumer<JoinableFile> fileConsumer )
+    {
+        forAll( entryMap, entry -> entry.getFile() != null, entry -> fileConsumer.accept( entry.getFile() ) );
+    }
+
+    /**
+     * Iterate all {@link FileTree.FileEntry instances} to extract information about active locks.
+     *
+     * @param predicate The selector determining which files to analyze.
+     * @param fileConsumer The operation to extract information from a single active file.
+     */
+    public static void forAll( Map<String, FileTree.FileEntry> entryMap,
+                               Predicate<? super FileTree.FileEntry> predicate,
+                               Consumer<FileTree.FileEntry> fileConsumer )
+    {
+        TreeMap<String, FileTree.FileEntry> sorted = new TreeMap<>( entryMap );
+        sorted.forEach( ( key, entry ) -> {
+            if ( entry != null && predicate.test( entry ) )
+            {
+                fileConsumer.accept( entry );
+            }
+        } );
+    }
+
+    /**
+     * Render the active files as a tree structure, for output to a log file or other string-oriented output.
+     */
+    public static String renderTree( Map<String, FileTree.FileEntry> entryMap )
+    {
+        TreeMap<String, FileTree.FileEntry> sorted = new TreeMap<>( entryMap );
+        StringBuilder sb = new StringBuilder();
+        sorted.forEach( ( key, entry ) -> {
+            sb.append( "+- " );
+            Stream.of( key.split( "/" ) ).forEach( ( part ) -> sb.append( "  " ) );
+
+            sb.append( new File( key ).getName() );
+            if ( entry.getFile() != null )
+            {
+                sb.append( " (F)" );
+            }
+            else
+            {
+                sb.append( "/" );
+            }
+        } );
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/commonjava/util/partyline/FileTreeTest.java
+++ b/src/test/java/org/commonjava/util/partyline/FileTreeTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.concurrent.TimeUnit;
 
+import static org.commonjava.util.partyline.util.FileTreeUtils.renderTree;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -107,7 +108,7 @@ public class FileTreeTest
         //        JoinableFile jf = new JoinableFile( child, false );
         //        root.add( jf );
 
-        System.out.println( "File tree rendered as:\n" + root.renderTree() );
+        System.out.println( "File tree rendered as:\n" + renderTree( root.getUnmodifiableEntryMap() ) );
     }
 
     private File createStructure( String path, boolean writeTestFile )

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.commonjava.util.partyline.fixture.ThreadDumper.timeoutRule;
 import static org.commonjava.util.partyline.lock.local.LocalLockOwner.PARTYLINE_LOCK_OWNER;
+import static org.commonjava.util.partyline.util.FileTreeUtils.forAll;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -327,7 +328,7 @@ public class JoinableFileManagerTest
         assertThat( "Threads did not end correctly!", end.getCount(), equalTo( 0L ) );
 
         AtomicInteger counter = new AtomicInteger( 0 );
-        mgr.getFileTree().forAll( entry->true, entry->counter.incrementAndGet() );
+        forAll( mgr.getFileTree().getUnmodifiableEntryMap(), entry->true, entry->counter.incrementAndGet() );
 
         assertThat( "FileEntry instance was not removed after closing!", counter.get(), equalTo( 0 ) );
     }
@@ -418,7 +419,7 @@ public class JoinableFileManagerTest
         assertThat( "Threads did not end correctly!", end.getCount(), equalTo( 0L ) );
 
         AtomicInteger counter = new AtomicInteger( 0 );
-        mgr.getFileTree().forAll( entry->true, entry->counter.incrementAndGet() );
+        forAll( mgr.getFileTree().getUnmodifiableEntryMap(), entry->true, entry->counter.incrementAndGet() );
 
         assertThat( "FileEntry instance was not removed after closing!", counter.get(), equalTo( 0 ) );
     }

--- a/src/test/java/org/commonjava/util/partyline/OpenOutputStreamSecondWaitsUntilFirstCloseTest.java
+++ b/src/test/java/org/commonjava/util/partyline/OpenOutputStreamSecondWaitsUntilFirstCloseTest.java
@@ -43,8 +43,8 @@ public class OpenOutputStreamSecondWaitsUntilFirstCloseTest
 {
 
     /**
-     * Test aligns two concurrent writing tasks as second starts until first close, operated on the same file verified to be available, this setup an script of events for
-     * one single file, where:
+     * Test aligns two concurrent writing tasks as second starts until first close, operated on the same file
+     * verified to be available, this setup an script of events for one single file, where:
      * <ol>
      *     <li>Multiple writes happened as a specific sequence</li>
      *     <li>Has no simultaneous Writing lock on the same file</li>
@@ -53,8 +53,8 @@ public class OpenOutputStreamSecondWaitsUntilFirstCloseTest
      */
     @BMRules( rules = {
             // wait for first openOutputStream call to exit
-            @BMRule( name = "second openOutputStream", targetClass = "JoinableFileManager",
-                     targetMethod = "openOutputStream",
+            @BMRule( name = "second openOutputStream", targetClass = "Partyline",
+                     targetMethod = "openOutputStream(File)",
                      targetLocation = "ENTRY",
                      condition = "$2==100",
                      action = "debug(\">>>wait for service enter first openOutputStream.\");"
@@ -62,8 +62,8 @@ public class OpenOutputStreamSecondWaitsUntilFirstCloseTest
                              + "debug(\"<<<proceed with second openOutputStream.\")" ),
 
             // setup the trigger to signal second openOutputStream when the first openOutputStream exits
-            @BMRule( name = "first openOutputStream", targetClass = "JoinableFileManager",
-                     targetMethod = "openOutputStream",
+            @BMRule( name = "first openOutputStream", targetClass = "Partyline",
+                     targetMethod = "openOutputStream(File)",
                      targetLocation = "EXIT",
                      condition = "$2==-1",
                      action = "debug(\"<<<signalling second openOutputStream.\"); "


### PR DESCRIPTION
This PR is about removing synchronized modifier from getNearestLockingEntry( File file )
The synchronized was on the FileTree object so that all the threads had to sync. This was an application level bottleneck. In fact, we don't need it. The entryMap is a concurrent map and we don't do any further sync whenever it is used. (Of course, we use opLock in other places but the opLock is per File, not a global lock)