### PR TITLE
Add GlobalLockManager for cluster env

### DIFF
--- a/src/main/java/org/commonjava/util/partyline/Partyline.java
+++ b/src/main/java/org/commonjava/util/partyline/Partyline.java
@@ -19,6 +19,7 @@ import org.commonjava.cdi.util.weft.ThreadContext;
 import org.commonjava.util.partyline.lock.LockLevel;
 import org.commonjava.util.partyline.impl.local.RandomAccessJF;
 import org.commonjava.util.partyline.impl.local.RandomAccessJFS;
+import org.commonjava.util.partyline.lock.global.GlobalLockManager;
 import org.commonjava.util.partyline.spi.JoinableFilesystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,7 +138,12 @@ public class Partyline
         this( new RandomAccessJFS() );
     }
 
-    public Partyline(JoinableFilesystem filesystem)
+    public Partyline( GlobalLockManager globalLockManager ) // for cluster env
+    {
+        this( new RandomAccessJFS( globalLockManager ) );
+    }
+
+    public Partyline( JoinableFilesystem filesystem )
     {
         this.timer = new Timer( true );
         this.locks = new FileTree( filesystem );

--- a/src/main/java/org/commonjava/util/partyline/Partyline.java
+++ b/src/main/java/org/commonjava/util/partyline/Partyline.java
@@ -135,18 +135,18 @@ public class Partyline
 
     public Partyline()
     {
-        this( new RandomAccessJFS() );
+        this( new RandomAccessJFS(), null );
     }
 
     public Partyline( GlobalLockManager globalLockManager ) // for cluster env
     {
-        this( new RandomAccessJFS( globalLockManager ) );
+        this( new RandomAccessJFS( globalLockManager ), globalLockManager );
     }
 
-    public Partyline( JoinableFilesystem filesystem )
+    private Partyline( JoinableFilesystem filesystem, GlobalLockManager globalLockManager )
     {
         this.timer = new Timer( true );
-        this.locks = new FileTree( filesystem );
+        this.locks = new FileTree( filesystem, globalLockManager );
     }
 
     FileTree getFileTree()

--- a/src/main/java/org/commonjava/util/partyline/lock/global/GlobalLockManager.java
+++ b/src/main/java/org/commonjava/util/partyline/lock/global/GlobalLockManager.java
@@ -1,0 +1,32 @@
+package org.commonjava.util.partyline.lock.global;
+
+import org.commonjava.util.partyline.PartylineException;
+import org.commonjava.util.partyline.lock.LockLevel;
+
+/**
+ * GlobalLockManager is for cluster Env.
+ *
+ * Each node needs to get a lock before reading or writing to a path and unlock it once finish r/w operations.
+ * When a path is r-locked by a node, other nodes can add r-lock to it, but w-lock is forbidden.
+ * When a path is w-locked by a node, other nodes can not add any further locks.
+ *
+ * This does not affect threads on local node. All the threads can still join the reading when one thread is writing.
+ */
+public interface GlobalLockManager
+{
+    /**
+     * Try to lock a path.
+     * @param path
+     * @param level
+     * @param timeoutInMillis
+     * @return true if succeeded. false if failed to lock during the timeout limit.
+     */
+    boolean tryLock( String path, LockLevel level, long timeoutInMillis ) throws PartylineException;
+
+    /**
+     * Unlock a path.
+     * @param path
+     * @param level
+     */
+    void unlock( String path, LockLevel level ) throws PartylineException;
+}

--- a/src/main/java/org/commonjava/util/partyline/lock/global/GlobalLockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/lock/global/GlobalLockOwner.java
@@ -1,0 +1,63 @@
+package org.commonjava.util.partyline.lock.global;
+
+import org.commonjava.util.partyline.lock.LockLevel;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.HashSet;
+import java.util.Set;
+
+public class GlobalLockOwner
+                implements Externalizable
+{
+    LockLevel level;
+
+    public GlobalLockOwner( LockLevel level )
+    {
+        this.level = level;
+    }
+
+    Set<String> ownerSet = new HashSet<>();
+
+    public GlobalLockOwner withOwner( String id )
+    {
+        ownerSet.add( id );
+        return this;
+    }
+
+    public LockLevel getLevel()
+    {
+        return level;
+    }
+
+    public boolean containsOwner( String id )
+    {
+        return ownerSet.contains( id );
+    }
+
+    public void removeOwner( String id )
+    {
+        ownerSet.remove( id );
+    }
+
+    public boolean isEmpty()
+    {
+        return ownerSet.isEmpty();
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput objectOutput ) throws IOException
+    {
+        objectOutput.writeObject( level.name() );
+        objectOutput.writeObject( ownerSet );
+    }
+
+    @Override
+    public void readExternal( ObjectInput objectInput ) throws IOException, ClassNotFoundException
+    {
+        level = LockLevel.valueOf( (String) objectInput.readObject() );
+        ownerSet = (Set) objectInput.readObject();
+    }
+}

--- a/src/main/java/org/commonjava/util/partyline/lock/global/impl/InfinispanGLM.java
+++ b/src/main/java/org/commonjava/util/partyline/lock/global/impl/InfinispanGLM.java
@@ -1,0 +1,199 @@
+package org.commonjava.util.partyline.lock.global.impl;
+
+import org.commonjava.util.partyline.PartylineException;
+import org.commonjava.util.partyline.lock.LockLevel;
+import org.commonjava.util.partyline.lock.global.GlobalLockManager;
+import org.commonjava.util.partyline.lock.global.GlobalLockOwner;
+import org.infinispan.Cache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.System.currentTimeMillis;
+import static java.lang.Thread.sleep;
+
+public class InfinispanGLM
+                implements GlobalLockManager
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private final static long DEFAULT_EXPIRATION_IN_MINUTES = 30;
+
+    private final Cache<String, GlobalLockOwner> lockCache;
+
+    private final String id;
+
+    /**
+     * The lockCache must be a distributed and transactional cache being accessed by all nodes.
+     * @param lockCache
+     */
+    public InfinispanGLM( Cache<String, GlobalLockOwner> lockCache )
+    {
+        this.lockCache = lockCache;
+        this.id = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public boolean tryLock( String path, LockLevel level, long timeoutInMillis ) throws PartylineException
+    {
+        long cur = currentTimeMillis();
+        long end;
+        if ( timeoutInMillis <= 0 )
+        {
+            end = Long.MAX_VALUE;
+        }
+        else
+        {
+            end = cur + timeoutInMillis;
+        }
+
+        TransactionManager txManager = lockCache.getAdvancedCache().getTransactionManager();
+
+        while ( cur < end )
+        {
+            Boolean locked = executeInTransaction( txManager, () -> {
+                GlobalLockOwner lock = lockCache.get( path );
+                if ( lock == null )
+                {
+                    putWithExpiration( path, new GlobalLockOwner( level ).withOwner( this.id ) );
+                    return true;
+                }
+
+                // if some node is reading and this node want to read too, add this to owner list
+                if ( lock.getLevel() == LockLevel.read && level == LockLevel.read )
+                {
+                    if ( !lock.containsOwner( this.id ) )
+                    {
+                        lock.withOwner( this.id );
+                        putWithExpiration( path, lock );
+                    }
+                    return true;
+                }
+                return false;
+            } );
+
+            if ( locked == null || !locked )
+            {
+                sleepQuietly( 100 );
+            }
+            cur = currentTimeMillis();
+        }
+        return false;
+    }
+
+    @Override
+    public void unlock( String path, LockLevel level ) throws PartylineException
+    {
+        if ( level == LockLevel.write )
+        {
+            lockCache.remove( path );
+            return;
+        }
+
+        TransactionManager txManager = lockCache.getAdvancedCache().getTransactionManager();
+        Boolean ret = executeInTransaction( txManager, () -> {
+            GlobalLockOwner lock = lockCache.get( path );
+            if ( lock == null )
+            {
+                return true;
+            }
+            if ( lock.containsOwner( this.id ) )
+            {
+                lock.removeOwner( this.id );
+                if ( lock.isEmpty() )
+                {
+                    lockCache.remove( path );
+                }
+                else
+                {
+                    putWithExpiration( path, lock );
+                }
+            }
+            return true;
+        } );
+    }
+
+    private void putWithExpiration( String path, GlobalLockOwner lock )
+    {
+        lockCache.put( path, lock, DEFAULT_EXPIRATION_IN_MINUTES, TimeUnit.MINUTES );
+    }
+
+    private void sleepQuietly( long milliseconds )
+    {
+        try
+        {
+            sleep( milliseconds );
+        }
+        catch ( InterruptedException e )
+        {
+            ;
+        }
+    }
+
+    /**
+     * If transaction not supported, we throw PartylineException to inform the caller to not try again. For other
+     * transactional exceptions, we return null to let caller retry later.
+     * @param txManager
+     * @param operation
+     * @param <T>
+     * @return
+     * @throws PartylineException
+     */
+    private <T> T executeInTransaction( TransactionManager txManager, TransactionalOperation<T> operation )
+                    throws PartylineException
+    {
+        try
+        {
+            txManager.begin();
+        }
+        catch ( NotSupportedException e )
+        {
+            throw new PartylineException( "Transaction not supported", e );
+        }
+        catch ( SystemException e )
+        {
+            logger.error( "Failed to begin transaction.", e );
+            return null;
+        }
+
+        try
+        {
+            T ret = operation.execute();
+            txManager.commit();
+            return ret;
+        }
+        catch ( SystemException | RollbackException | HeuristicMixedException | HeuristicRollbackException e )
+        {
+            logger.warn( "Failed to commit transaction.", e );
+            return null;
+        }
+        catch ( Exception e )
+        {
+            try
+            {
+                txManager.rollback();
+                logger.error( "Failed to execute. Rolling back.", e );
+            }
+            catch ( SystemException e1 )
+            {
+                logger.error( "Exception during rollback", e1 );
+            }
+        }
+        return null;
+    }
+
+    @FunctionalInterface
+    interface TransactionalOperation<T>
+    {
+        T execute() throws Exception;
+    }
+
+}

--- a/src/main/java/org/commonjava/util/partyline/lock/global/impl/InfinispanGLM.java
+++ b/src/main/java/org/commonjava/util/partyline/lock/global/impl/InfinispanGLM.java
@@ -134,7 +134,7 @@ public class InfinispanGLM
         }
         catch ( InterruptedException e )
         {
-            ;
+            logger.trace( "Sleep interrupted: {}", e );
         }
     }
 

--- a/src/test/java/org/commonjava/util/partyline/OpenOutputStreamSecondWaitsUntilFirstCloseTest.java
+++ b/src/test/java/org/commonjava/util/partyline/OpenOutputStreamSecondWaitsUntilFirstCloseTest.java
@@ -54,16 +54,16 @@ public class OpenOutputStreamSecondWaitsUntilFirstCloseTest
     @BMRules( rules = {
             // wait for first openOutputStream call to exit
             @BMRule( name = "second openOutputStream", targetClass = "Partyline",
-                     targetMethod = "openOutputStream(File)",
+                     targetMethod = "openOutputStream(File,long)",
                      targetLocation = "ENTRY",
                      condition = "$2==100",
                      action = "debug(\">>>wait for service enter first openOutputStream.\");"
-                             + "waitFor(\"first openOutputStream\");" + "java.lang.Thread.sleep(10);"
+                             + "waitFor(\"first openOutputStream\");" + "java.lang.Thread.sleep(100);"
                              + "debug(\"<<<proceed with second openOutputStream.\")" ),
 
             // setup the trigger to signal second openOutputStream when the first openOutputStream exits
             @BMRule( name = "first openOutputStream", targetClass = "Partyline",
-                     targetMethod = "openOutputStream(File)",
+                     targetMethod = "openOutputStream(File,long)",
                      targetLocation = "EXIT",
                      condition = "$2==-1",
                      action = "debug(\"<<<signalling second openOutputStream.\"); "


### PR DESCRIPTION
It seems for cluster we can use a simpler lock. If one node opens a file to write, we just forbid other nodes to r/w. Because other nodes cannot read the on-the-fly bytes. If one node opens a file for reading, we forbid others to write but allow to read. For deletion, we can just use the write lock.  
Briefly, we only need r or w levels for global locks. 