### PR TITLE
remove map of operation locks and move to SignallingLocker from Weft

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </scm>
   
   <properties>
-    <weftVersion>1.6</weftVersion>
+    <weftVersion>1.12-SNAPSHOT</weftVersion>
 
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>

--- a/src/main/java/org/commonjava/util/partyline/ExceptionUtils.java
+++ b/src/main/java/org/commonjava/util/partyline/ExceptionUtils.java
@@ -15,19 +15,33 @@
  */
 package org.commonjava.util.partyline;
 
-import org.commonjava.cdi.util.weft.SignallingLock;
-import org.commonjava.cdi.util.weft.SignallingLockOperation;
-
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
 
-/**
- * Created by jdcasey on 12/8/16.
- */
-@FunctionalInterface
-public interface LockedFileOperation<T>
+class ExceptionUtils
 {
-    T apply( String path, AtomicReference<Exception> error, SignallingLock opLock );
+    static void handleError( AtomicReference<Exception> error, String label )
+            throws IOException, InterruptedException
+    {
+        Exception e = error.get();
+        if ( e != null )
+        {
+            if ( e instanceof IOException )
+            {
+                throw (IOException) e;
+            }
 
+            if ( e instanceof InterruptedException )
+            {
+                throw (InterruptedException) e;
+            }
+
+            if ( e instanceof RuntimeException )
+            {
+                throw (RuntimeException) e;
+            }
+
+            throw new IOException( "Operation failed: " + label, e );
+        }
+    }
 }

--- a/src/test/java/org/commonjava/util/partyline/AbstractJointedIOTest.java
+++ b/src/test/java/org/commonjava/util/partyline/AbstractJointedIOTest.java
@@ -15,9 +15,13 @@
  */
 package org.commonjava.util.partyline;
 
+import org.commonjava.cdi.util.weft.SignallingLocker;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
+
+import java.io.File;
+import java.io.IOException;
 
 public abstract class AbstractJointedIOTest
 {
@@ -30,8 +34,17 @@ public abstract class AbstractJointedIOTest
     @Rule
     public TestName name = new TestName();
 
+    private final SignallingLocker<String> locker = new SignallingLocker<>();
+
+
     protected int readers = 0;
 
     protected int writers = 0;
+
+    protected JoinableFile newFile( final File f, final LockOwner lockOwner, final boolean doOutput )
+            throws IOException
+    {
+        return new JoinableFile( f, lockOwner, null, doOutput, locker );
+    }
 
 }

--- a/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/BinaryFileTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.fail;
  * Date: 9/3/16
  * Time: 10:46 PM
  */
-public class BinaryFileTest {
+public class BinaryFileTest extends AbstractJointedIOTest {
 
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
@@ -70,7 +70,7 @@ public class BinaryFileTest {
 
         File binaryFile = temp.newFile( "binary-file.bin" );
         ReentrantLock lock = new ReentrantLock();
-        JoinableFile jf = new JoinableFile( binaryFile, new LockOwner( binaryFile.getAbsolutePath(),
+        JoinableFile jf = newFile( binaryFile, new LockOwner( binaryFile.getAbsolutePath(),
                                                                          name.getMethodName(), LockLevel.write ), true );
         OutputStream jos = jf.getOutputStream();
         InputStream actual = jf.joinStream();

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteAndCloseBeforeFinishedTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteAndCloseBeforeFinishedTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteAndCloseBeforeFinishedTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
+                newFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteJustBeforeFinishedTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteJustBeforeFinishedTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteJustBeforeFinishedTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
+                newFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteTest.java
@@ -68,7 +68,7 @@ public class JoinFileWriteTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
+                newFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinFileWriteTwiceWithDelayTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinFileWriteTwiceWithDelayTest.java
@@ -73,7 +73,7 @@ public class JoinFileWriteTwiceWithDelayTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
+                newFile( file, new LockOwner( file.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileManagerPerformanceTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileManagerPerformanceTest.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.util.partyline;
 
+import org.commonjava.cdi.util.weft.SignallingLocker;
 import org.junit.Test;
 
 import java.io.File;
@@ -42,7 +43,10 @@ public class JoinableFileManagerPerformanceTest
 
         String content = createBigFileContent();
 
-        JoinableFile jf = new JoinableFile( jft, new LockOwner( jft.getPath(), "write test", LockLevel.write ), true);
+        JoinableFile jf =
+                new JoinableFile( jft, new LockOwner( jft.getPath(), "write test", LockLevel.write ), null, true,
+                                  new SignallingLocker<String>() );
+
         long start = System.currentTimeMillis();
         System.out.println("Opening output...");
         try(OutputStream out = jf.getOutputStream())

--- a/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
+++ b/src/test/java/org/commonjava/util/partyline/JoinableFileTest.java
@@ -18,6 +18,8 @@ package org.commonjava.util.partyline;
 import ch.qos.logback.core.util.FileSize;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.commonjava.cdi.util.weft.SignallingLock;
+import org.commonjava.cdi.util.weft.SignallingLocker;
 import org.commonjava.util.partyline.fixture.TimedFileWriter;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,7 +62,7 @@ public class JoinableFileTest
         String src = "This is a test";
         FileUtils.write( f, src );
 
-        final JoinableFile stream = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
+        final JoinableFile stream = newFile(f, newLockOwner( f.getAbsolutePath(), read ), false );
 
         System.out.println( "File length: " + f.length() );
 
@@ -102,7 +104,7 @@ public class JoinableFileTest
             IOUtils.write( src, out );
         }
 
-        final JoinableFile jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
+        final JoinableFile jf = newFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
 
         try(InputStream stream = jf.joinStream())
         {
@@ -117,7 +119,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
+        JoinableFile jf = newFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
 
@@ -130,7 +132,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
+        JoinableFile jf = newFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
 
@@ -146,7 +148,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
+        JoinableFile jf = newFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
         assertThat( jf.isJoinable(), equalTo( false ) );
@@ -160,7 +162,7 @@ public class JoinableFileTest
     {
         File dir = temp.newFolder();
         dir.mkdirs();
-        JoinableFile jf = new JoinableFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
+        JoinableFile jf = newFile( dir, newLockOwner( dir.getAbsolutePath(), read ), false );
 
         assertThat( jf.isWriteLocked(), equalTo( true ) );
 
@@ -178,7 +180,7 @@ public class JoinableFileTest
         String threadName = "writer" + writers++;
 
         final JoinableFile stream =
-                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
+                newFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );
@@ -203,14 +205,14 @@ public class JoinableFileTest
             throws Exception
     {
         File f = temp.newFile();
-        JoinableFile jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), write ), true );
+        JoinableFile jf = newFile( f, newLockOwner( f.getAbsolutePath(), write ), true );
         OutputStream stream = jf.getOutputStream();
 
         String longer = "This is a really really really long string";
         stream.write( longer.getBytes() );
         stream.close();
 
-        jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), write ), true );
+        jf = newFile( f, newLockOwner( f.getAbsolutePath(), write ), true );
         stream = jf.getOutputStream();
 
         String shorter = "This is a short string";
@@ -241,7 +243,7 @@ public class JoinableFileTest
         Logger logger = LoggerFactory.getLogger( getClass() );
         try
         {
-            jf = new JoinableFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
+            jf = newFile( f, newLockOwner( f.getAbsolutePath(), read ), false );
             s1 = jf.joinStream();
             s2 = jf.joinStream();
 
@@ -275,8 +277,7 @@ public class JoinableFileTest
         final File tempFile = temp.newFile();
         String threadName = "writer" + writers++;
 
-        final JoinableFile stream =
-                new JoinableFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
+        final JoinableFile stream = newFile( tempFile, new LockOwner( tempFile.getAbsolutePath(), name.getMethodName(), LockLevel.write ), true );
 
         execs.execute( () -> {
             Thread.currentThread().setName( threadName );
@@ -299,4 +300,5 @@ public class JoinableFileTest
 
         assertThat( lines.size(), equalTo( COUNT ) );
     }
+
 }

--- a/src/test/java/org/commonjava/util/partyline/ManyReadersWithPreExistingWriterTest.java
+++ b/src/test/java/org/commonjava/util/partyline/ManyReadersWithPreExistingWriterTest.java
@@ -16,7 +16,7 @@
 package org.commonjava.util.partyline;
 
 import org.apache.commons.io.IOUtils;
-import org.commonjava.cdi.util.weft.ContextSensitiveExecutorService;
+import org.commonjava.cdi.util.weft.PoolWeftExecutorService;
 import org.commonjava.cdi.util.weft.ThreadContext;
 import org.commonjava.util.partyline.fixture.ThreadDumper;
 import org.junit.Before;
@@ -33,15 +33,13 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -58,7 +56,8 @@ public class ManyReadersWithPreExistingWriterTest
 
     private static final int ITERATIONS = 2;
 
-    private ExecutorService executor = new ContextSensitiveExecutorService( Executors.newCachedThreadPool() );
+    private ExecutorService executor = new PoolWeftExecutorService( "test",
+                                                                    (ThreadPoolExecutor) Executors.newCachedThreadPool() );
 
     private final JoinableFileManager mgr = new JoinableFileManager();
 


### PR DESCRIPTION
This will allow us to clean up unused lock entries and reclaim the heap space.

Depends on https://github.com/Commonjava/weft/pull/33