### PR TITLE
Add jvm flag to permit attaching to JVM during tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <forkCount>${test-forkCount}</forkCount>
             <reuseForks>false</reuseForks>
+            <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
 This PR ensures the Maven test goal to operate. As it did with JDK8.