### PR TITLE
Update versions. Remove commons-lang:2.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>commonjava</artifactId>
-    <version>13</version>
+    <version>21</version>
   </parent>
 
   <groupId>org.commonjava.util</groupId>
@@ -30,21 +30,22 @@
 
   <name>partyline</name>
   <inceptionYear>2015</inceptionYear>
-  
+
   <scm>
     <connection>scm:git:https://github.com/Commonjava/partyline.git</connection>
     <developerConnection>scm:git:git@github.com:Commonjava/partyline.git</developerConnection>
     <url>https://github.com/Commonjava/partyline</url>
     <tag>HEAD</tag>
   </scm>
-  
+
   <properties>
-    <weftVersion>1.14</weftVersion>
-    <infinispanVersion>9.4.7.Final</infinispanVersion>
+    <weftVersion>1.25</weftVersion>
+    <!-- Match the version currently being used by Indy -->
+    <infinispanVersion>9.4.24.Final</infinispanVersion>
     <projectOwner>Red Hat, Inc.</projectOwner>
     <projectEmail>nos-devel@redhat.com</projectEmail>
     <javaVersion>1.8</javaVersion>
-    <byteman.version>3.0.6</byteman.version>
+    <byteman.version>4.0.26</byteman.version>
     <test-forkCount>1</test-forkCount>
 
     <plugin.jacoco.skip>false</plugin.jacoco.skip>
@@ -55,7 +56,7 @@
       <dependency>
         <groupId>org.commonjava.boms</groupId>
         <artifactId>web-commons-bom</artifactId>
-        <version>21</version>
+        <version>31</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -100,7 +101,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -119,10 +120,6 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman</artifactId>
     </dependency>
@@ -139,6 +136,10 @@
       <artifactId>byteman-bmunit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.cdi.util</groupId>
       <artifactId>weft</artifactId>
     </dependency>
@@ -153,10 +154,9 @@
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-      <version>3.3.0.Final</version>
     </dependency>
   </dependencies>
-  
+
   <build>
     <pluginManagement>
       <plugins>

--- a/src/main/java/org/commonjava/util/partyline/Partyline.java
+++ b/src/main/java/org/commonjava/util/partyline/Partyline.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 import static org.commonjava.util.partyline.lock.LockLevel.read;
 import static org.commonjava.util.partyline.lock.local.LocalLockOwner.getLockReservationName;

--- a/src/main/java/org/commonjava/util/partyline/lock/local/LocalLockOwner.java
+++ b/src/main/java/org/commonjava/util/partyline/lock/local/LocalLockOwner.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.commons.lang.StringUtils.join;
-
 /**
  * Maintain information about threads with active locks on a file, along the current lock-level of the file (which
  * determines what additional operations can be added, once the initial operation is started). This class counts

--- a/src/test/java/org/commonjava/util/partyline/fixture/ThreadDumper.java
+++ b/src/test/java/org/commonjava/util/partyline/fixture/ThreadDumper.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * Created by jdcasey on 11/28/16.


### PR DESCRIPTION
@sswguo I notice there is no gh-actions enabled - perhaps that should be done in a separate PR, then this rebased on top so a full action run can be done? I've added https://github.com/Commonjava/partyline/pull/126 